### PR TITLE
fix(docker): bump Go to 1.20 and unblock docker-compose build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 aws
+docker-compose.override.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM --platform=linux/amd64 golang:1.17
+FROM --platform=linux/amd64 golang:1.20
 
 # ワーキングディレクトリを設定
 WORKDIR /app
@@ -13,9 +13,6 @@ COPY go.sum .
 
 # 依存関係のインストール
 RUN go mod download
-
-# gooseをインストール
-RUN go get -u github.com/pressly/goose/cmd/goose
 
 # ソースコードをコピー
 COPY . .


### PR DESCRIPTION
## Summary
ローカル開発で `docker compose up --build` が失敗する問題を修正。

- **Go バージョン 1.17 → 1.20**: go.mod の `go 1.20` に一致させる
- **`go get -u github.com/pressly/goose/cmd/goose` を削除**: Go 1.17 以降は `go get` によるバイナリインストールが非対応でビルド失敗の原因になっていた。CMD でも使われておらず削除しても影響なし
- **`.gitignore` に `docker-compose.override.yml` を追加**: ローカル環境ごとのポート設定などを override で書く慣習に対応

## 背景
ローカルで `docker compose up --build` を実行したところ、以下のエラーでビルドが失敗した：
```
#11 ERROR: process "/bin/sh -c go get -u github.com/pressly/goose/cmd/goose" did not complete successfully: exit code: 1
```

## Test plan
- [x] `docker compose up -d --build` でコンテナが起動すること
- [x] `curl http://localhost:8080/healthcheck` が 200 を返すこと
- [x] goose マイグレーションがホストから適用できること（`goose mysql "..." up` が成功）