### PR TITLE
feat(lab): LocalStack+Postgres+Redis 環境を追加 (Day 1 #0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ PitaScho（オンラインカウンセリング相談予約サービス）のカ
 
 ## 技術スタック
 
-- **言語**: Go 1.20（go.mod）/ Dockerfile は Go 1.17 — バージョン不一致あり
+- **言語**: Go 1.20
 - **Web フレームワーク**: Echo v4.10
 - **ORM**: GORM v1.25
 - **DB**: MySQL 8.0（ドライバ: go-sql-driver/mysql）
@@ -36,9 +36,24 @@ db/
 |------|---------|
 | ビルド | `go build -o main .` |
 | 起動 | `./main`（ポート 8080） |
-| ローカル起動（DB 込み） | `docker-compose up` |
+| ローカル起動（最小: MySQL + backend） | `make up` |
+| ローカル起動（lab 用 LocalStack / Postgres / Redis 込み） | `make up-lab` |
+| 停止 | `make down` |
+| ログ追従 | `make logs` |
 
 ※ CI にテストステップの定義はあるが、実装は空。
+
+## lab トピック用の追加サービス
+
+`docker-compose.lab.yml` が以下を追加する：
+
+| サービス | 用途 | ホスト側ポート |
+|---------|-----|----------|
+| LocalStack | S3 / SQS / SNS / Lambda | 4566 |
+| Postgres | RLS / パーティショニング / bulk | 5433 |
+| Redis | Cache-Aside | 6379 |
+
+初期化は `scripts/init-localstack.sh`（SQS キュー / SNS トピック / S3 バケット作成）と `scripts/init-postgres.sql` が自動実行する。
 
 ## API 概要
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: up up-lab down logs ps rebuild
+
+COMPOSE_LAB = docker compose -f docker-compose.yml -f docker-compose.lab.yml -f docker-compose.override.yml
+
+# 既存の最小構成 (mysql + backend のみ)
+up:
+	docker compose up -d
+
+# lab トピック用の追加サービス込み (LocalStack, Postgres, Redis)
+up-lab:
+	$(COMPOSE_LAB) up -d
+
+down:
+	$(COMPOSE_LAB) down
+
+logs:
+	$(COMPOSE_LAB) logs -f --tail 100
+
+ps:
+	$(COMPOSE_LAB) ps
+
+rebuild:
+	$(COMPOSE_LAB) up -d --build

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -1,0 +1,57 @@
+# lab 用の追加サービス。使い方:
+#   docker compose -f docker-compose.yml -f docker-compose.lab.yml up -d
+#
+# 既存のローカル開発 (MySQL + backend) に加えて、以下を起動する:
+#   - LocalStack (S3/SQS/SNS/Lambda)
+#   - PostgreSQL (RLS / パーティショニング / bulk 用、既存 MySQL と併存)
+#   - Redis (Cache-Aside 用)
+#
+# ポート衝突回避などの個人設定は docker-compose.override.yml を別に用意する。
+
+services:
+  backend:
+    environment:
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      POSTGRES_DSN: postgres://lab:lab@postgres:5432/lab?sslmode=disable
+      REDIS_ADDR: redis:6379
+    depends_on:
+      - mysql
+      - localstack
+      - postgres
+      - redis
+
+  localstack:
+    image: localstack/localstack:3.8
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: s3,sqs,sns,lambda
+      DEBUG: "0"
+      DEFAULT_REGION: ap-northeast-1
+      LAMBDA_EXECUTOR: docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./scripts/init-localstack.sh:/etc/localstack/init/ready.d/init.sh
+
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_USER: lab
+      POSTGRES_PASSWORD: lab
+      POSTGRES_DB: lab
+    volumes:
+      - postgres-lab-data:/var/lib/postgresql/data
+      - ./scripts/init-postgres.sql:/docker-entrypoint-initdb.d/init.sql
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres-lab-data:

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# LocalStack 起動時に実行される初期化スクリプト。
+# SQS キュー、SNS トピック、S3 バケットを用意する。
+
+ENDPOINT=http://localhost:4566
+REGION=ap-northeast-1
+
+echo "[init] creating S3 buckets"
+awslocal s3 mb s3://lab-uploads --region "$REGION"
+awslocal s3 mb s3://lab-lambda --region "$REGION"
+
+echo "[init] creating SQS queues"
+awslocal sqs create-queue --queue-name lab-primary --region "$REGION"
+awslocal sqs create-queue --queue-name lab-audit   --region "$REGION"
+awslocal sqs create-queue --queue-name lab-dlq     --region "$REGION"
+
+echo "[init] creating SNS topic"
+TOPIC_ARN=$(awslocal sns create-topic --name lab-events --region "$REGION" --query 'TopicArn' --output text)
+PRIMARY_ARN=$(awslocal sqs get-queue-attributes --queue-url "$ENDPOINT/000000000000/lab-primary" --attribute-names QueueArn --region "$REGION" --query 'Attributes.QueueArn' --output text)
+AUDIT_ARN=$(awslocal sqs get-queue-attributes   --queue-url "$ENDPOINT/000000000000/lab-audit"   --attribute-names QueueArn --region "$REGION" --query 'Attributes.QueueArn' --output text)
+
+echo "[init] subscribing SQS queues to SNS topic"
+awslocal sns subscribe --topic-arn "$TOPIC_ARN" --protocol sqs --notification-endpoint "$PRIMARY_ARN" --attributes RawMessageDelivery=true --region "$REGION"
+awslocal sns subscribe --topic-arn "$TOPIC_ARN" --protocol sqs --notification-endpoint "$AUDIT_ARN"   --attributes RawMessageDelivery=true --region "$REGION"
+
+echo "[init] done"

--- a/scripts/init-postgres.sql
+++ b/scripts/init-postgres.sql
@@ -1,0 +1,9 @@
+-- lab 用の Postgres 初期化スクリプト
+-- 個別トピック（RLS、パーティショニング、bulk）のテーブルは各トピック着手時に追加する
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- lab 全体で使う設定用の named parameter。RLS で参照する
+-- 例: SET LOCAL app.current_org_id = '...'
+-- Postgres では任意の custom GUC を SET できるが、NOT NULL が必要な場合は
+-- コード側で検証する


### PR DESCRIPTION
## Summary
lab カリキュラム Day 1 #0: 実装演習の土台となるサービスを docker-compose に追加。

## 追加内容
- **docker-compose.lab.yml**（追加ファイル）: LocalStack / Postgres 16 / Redis 7
- **scripts/init-localstack.sh**: SQS キュー 3 本（primary/audit/dlq）、SNS topic `lab-events`、S3 バケット 2 つ（lab-uploads/lab-lambda）、SNS → SQS サブスク 2 本
- **scripts/init-postgres.sql**: pgcrypto 拡張のみ。各トピックで必要なテーブルはそのトピックの PR で追加
- **Makefile**: `make up-lab` / `make down` / `make logs` など compose shortcut
- **CLAUDE.md**: 主要コマンドと lab 構成を追記

## Test plan
- [x] `make up-lab` で全 5 サービス起動
- [x] `curl http://localhost:8090/healthcheck` → 200
- [x] `awslocal s3 ls` / `sqs list-queues` / `sns list-topics` で初期リソース確認済
- [x] `psql -U lab -d lab -h localhost -p 5433 -c "SELECT 1"` で Postgres 疎通
- [x] `redis-cli PING` で Redis 疎通