### PR TITLE
feat(lab): SQS publish API と別プロセス worker を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,12 @@ PitaScho（オンラインカウンセリング相談予約サービス）のカ
 
 ```
 src/
-├── handlers/     HTTP ハンドラー層（auth, user, tag, school, counseling, health_check）
+├── handlers/     HTTP ハンドラー層（auth, user, tag, school, counseling, health_check, lab_s3, lab_sqs）
 ├── models/       DB モデル層（user, tag, schools, school_tag, counseling）
 └── routes/       ルーティング設定（routes.go）
+
+cmd/
+└── worker/       lab 用 SQS worker バイナリ（別プロセス起動）
 
 db/
 └── migrations/   goose 用 SQL マイグレーション
@@ -68,6 +71,10 @@ db/
   - `POST /api/lab/s3/multipart/complete` — ETag 集計し upload 確定
   - `POST /api/lab/s3/multipart/abort` — upload 中止（ゴミパート破棄）
   - `GET  /api/lab/s3/objects` — アップロード済みファイル一覧
+  - `POST /api/lab/sqs/publish` — lab-primary へメッセージ送信
+  - `GET  /api/lab/sqs/stats` — primary / dlq の概算メッセージ数
+
+lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。`lab-primary` を long polling で受信し、"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動を観察できる。
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 
@@ -83,6 +90,7 @@ main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 �
   - `AWS_PUBLIC_ENDPOINT_URL` — ブラウザ向け presigned URL 生成用 (`http://localhost:4566`)
   - `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
   - `LAB_S3_BUCKET`（既定 `lab-uploads`）
+  - `LAB_SQS_PRIMARY_URL`, `LAB_SQS_DLQ_URL`
   - `POSTGRES_DSN`, `REDIS_ADDR`
 
 ## CI/CD

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ RUN go mod download
 # ソースコードをコピー
 COPY . .
 
-# アプリケーションをビルド
-RUN GOOS=linux GOARCH=amd64 go build -o main .
+# アプリケーションをビルド（API 本体と lab worker バイナリの両方）
+RUN GOOS=linux GOARCH=amd64 go build -o main . \
+ && GOOS=linux GOARCH=amd64 go build -o worker ./cmd/worker
 
 # ポートをエクスポート
 EXPOSE 8080

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,90 @@
+// Package main は lab 用の SQS worker バイナリ。
+// docker-compose.lab.yml の worker サービスで起動し、lab-primary を long polling する。
+// メッセージ本文に "fail" を含む場合は DeleteMessage を呼ばず、visibility timeout 切れ
+// による再配信を発生させる（redrive policy により maxReceiveCount 到達で DLQ に移る）。
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	region := getenv("AWS_REGION", "ap-northeast-1")
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		log.Fatalf("load aws config: %v", err)
+	}
+
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+	})
+
+	queueURL := getenv("LAB_SQS_PRIMARY_URL", "http://localstack:4566/000000000000/lab-primary")
+	log.Printf("worker: starting, polling %s", queueURL)
+
+	for ctx.Err() == nil {
+		out, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(queueURL),
+			MaxNumberOfMessages: 10,
+			// long polling: メッセージが無ければ最大 20 秒サーバー側で待つ
+			// 空ポーリングによる無駄なリクエストと料金を抑える基本設定
+			WaitTimeSeconds: 20,
+			// 処理中は他 worker から見えないようにする。この時間内に DeleteMessage
+			// を呼ばないと再配信される（失敗扱い）
+			VisibilityTimeout: 10,
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				break
+			}
+			log.Printf("receive error: %v", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		for _, msg := range out.Messages {
+			body := aws.ToString(msg.Body)
+			log.Printf("worker: received: %s", body)
+			// ダミー処理（1 秒のウェイト）
+			time.Sleep(1 * time.Second)
+
+			if strings.Contains(body, "fail") {
+				log.Printf("worker: simulated failure for %q — skipping delete → redelivery", body)
+				continue
+			}
+
+			_, err := client.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+				QueueUrl:      aws.String(queueURL),
+				ReceiptHandle: msg.ReceiptHandle,
+			})
+			if err != nil {
+				log.Printf("delete error: %v", err)
+				continue
+			}
+			log.Printf("worker: processed: %s", body)
+		}
+	}
+	log.Println("worker: shutdown")
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -18,6 +18,8 @@ services:
       AWS_SECRET_ACCESS_KEY: test
       POSTGRES_DSN: postgres://lab:lab@postgres:5432/lab?sslmode=disable
       REDIS_ADDR: redis:6379
+      LAB_SQS_PRIMARY_URL: http://localstack:4566/000000000000/lab-primary
+      LAB_SQS_DLQ_URL: http://localstack:4566/000000000000/lab-dlq
     depends_on:
       - mysql
       - localstack
@@ -53,6 +55,19 @@ services:
     image: redis:7-alpine
     ports:
       - "6379:6379"
+
+  # lab 用 SQS worker。backend と同じ image を使い command だけ差し替える
+  worker:
+    build: .
+    command: ["./worker"]
+    environment:
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      LAB_SQS_PRIMARY_URL: http://localstack:4566/000000000000/lab-primary
+    depends_on:
+      - localstack
 
 volumes:
   postgres-lab-data:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-playground/validator/v10 v10.13.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1 h1:kU/eBN5+MWNo/LcbNa4hWDdN76hdc
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1/go.mod h1:Fw9aqhJicIVee1VytBBjH+l+5ov6/PhbtIK/u3rt/ls=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 h1:a1Fq/KXn75wSzoJaPQTgZO0wHGqE9mjFnylnqEPTchA=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10/go.mod h1:p6+MXNxW7IA6dMgHfTAzljuwSKD0NCm/4lbS4t6+7vI=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26 h1:jtUEQz/c14fCMkOX3r2/nhYmhXZas0XdcQhUaIW5ubY=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26/go.mod h1:gcJv70rH+Z/Q1PM3jKsJr6+vfKrDHJOfmKq7342+Vq8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 h1:x6bKbmDhsgSZwv6q19wY/u3rLk/3FGjJWyqKcIRufpE=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.16/go.mod h1:CudnEVKRtLn0+3uMV0yEXZ+YZOKnAtUJ5DmDhilVnIw=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 h1:oK/njaL8GtyEihkWMD4k3VgHCT64RQKkZwh0DG5j8ak=

--- a/main.go
+++ b/main.go
@@ -55,13 +55,17 @@ func main() {
 	healthCheckHandler := handlers.NewHealthCheckHandler()
 
 	// Lab 用ハンドラは LocalStack (AWS_ENDPOINT_URL) が無くても初期化自体は成功する
-	// 実際の S3 呼び出し時に LocalStack へ到達できなければエラーになる
+	// 実際の S3/SQS 呼び出し時に LocalStack へ到達できなければエラーになる
 	labS3Handler, err := handlers.NewLabS3Handler()
 	if err != nil {
 		e.Logger.Warnf("lab s3 handler init failed, /api/lab/s3/* disabled: %s", err.Error())
 	}
+	labSQSHandler, err := handlers.NewLabSQSHandler()
+	if err != nil {
+		e.Logger.Warnf("lab sqs handler init failed, /api/lab/sqs/* disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler)
 
 	e.Start(":8080")
 }

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -37,6 +37,21 @@ awslocal sqs create-queue --queue-name lab-primary --region "$REGION"
 awslocal sqs create-queue --queue-name lab-audit   --region "$REGION"
 awslocal sqs create-queue --queue-name lab-dlq     --region "$REGION"
 
+echo "[init] wiring redrive policy: lab-primary → lab-dlq after 3 failed receives"
+# DLQ の ARN を取得してから、primary に「maxReceiveCount=3 を超えたら DLQ に送る」
+# という RedrivePolicy を設定する。worker が "fail" を含むメッセージを消し損ねた
+# 時の挙動観察に使う（visibility timeout 切れ × 3 回 → DLQ 行き）
+REDRIVE_DLQ_ARN=$(awslocal sqs get-queue-attributes --queue-url "$ENDPOINT/000000000000/lab-dlq" --attribute-names QueueArn --region "$REGION" --query 'Attributes.QueueArn' --output text)
+cat > /tmp/sqs-redrive.json <<EOF
+{
+  "RedrivePolicy": "{\"deadLetterTargetArn\":\"$REDRIVE_DLQ_ARN\",\"maxReceiveCount\":\"3\"}"
+}
+EOF
+awslocal sqs set-queue-attributes \
+  --queue-url "$ENDPOINT/000000000000/lab-primary" \
+  --attributes file:///tmp/sqs-redrive.json \
+  --region "$REGION"
+
 echo "[init] creating SNS topic"
 TOPIC_ARN=$(awslocal sns create-topic --name lab-events --region "$REGION" --query 'TopicArn' --output text)
 PRIMARY_ARN=$(awslocal sqs get-queue-attributes --queue-url "$ENDPOINT/000000000000/lab-primary" --attribute-names QueueArn --region "$REGION" --query 'Attributes.QueueArn' --output text)

--- a/src/handlers/lab_sqs_handler.go
+++ b/src/handlers/lab_sqs_handler.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/labstack/echo/v4"
+)
+
+// LabSQSHandler は SQS への publish と queue stats 取得を提供する lab 用ハンドラ。
+// 実際にメッセージを消費する worker は別プロセス (cmd/worker) として動く。
+type LabSQSHandler struct {
+	client     *sqs.Client
+	primaryURL string
+	dlqURL     string
+}
+
+// NewLabSQSHandler は LocalStack 前提で SQS クライアントを初期化する。
+// primary / dlq の URL はそれぞれ LAB_SQS_PRIMARY_URL / LAB_SQS_DLQ_URL で上書き可。
+func NewLabSQSHandler() (*LabSQSHandler, error) {
+	ctx := context.Background()
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(getenv("AWS_REGION", "ap-northeast-1")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	client := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+	})
+
+	return &LabSQSHandler{
+		client:     client,
+		primaryURL: getenv("LAB_SQS_PRIMARY_URL", "http://localstack:4566/000000000000/lab-primary"),
+		dlqURL:     getenv("LAB_SQS_DLQ_URL", "http://localstack:4566/000000000000/lab-dlq"),
+	}, nil
+}
+
+type publishReq struct {
+	Body string `json:"body"`
+}
+
+type publishRes struct {
+	MessageID string `json:"messageId"`
+}
+
+// Publish はメッセージを lab-primary キューに送信する。
+func (h *LabSQSHandler) Publish(c echo.Context) error {
+	var req publishReq
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if req.Body == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "body required")
+	}
+	out, err := h.client.SendMessage(c.Request().Context(), &sqs.SendMessageInput{
+		QueueUrl:    aws.String(h.primaryURL),
+		MessageBody: aws.String(req.Body),
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, publishRes{MessageID: aws.ToString(out.MessageId)})
+}
+
+type queueAttr struct {
+	Visible  int `json:"visible"`
+	InFlight int `json:"inFlight"`
+	Delayed  int `json:"delayed"`
+}
+
+type statsRes struct {
+	Primary queueAttr `json:"primary"`
+	DLQ     queueAttr `json:"dlq"`
+}
+
+// Stats は primary / dlq の概算メッセージ数を返す。
+// SQS の Approximate 系属性は最終的整合性で、頻繁に呼んでも最新が返るとは限らない。
+func (h *LabSQSHandler) Stats(c echo.Context) error {
+	ctx := c.Request().Context()
+	primary, err := h.queueAttrs(ctx, h.primaryURL)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "primary: "+err.Error())
+	}
+	dlq, err := h.queueAttrs(ctx, h.dlqURL)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "dlq: "+err.Error())
+	}
+	return c.JSON(http.StatusOK, statsRes{Primary: primary, DLQ: dlq})
+}
+
+func (h *LabSQSHandler) queueAttrs(ctx context.Context, url string) (queueAttr, error) {
+	out, err := h.client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl: aws.String(url),
+		AttributeNames: []types.QueueAttributeName{
+			types.QueueAttributeNameApproximateNumberOfMessages,
+			types.QueueAttributeNameApproximateNumberOfMessagesNotVisible,
+			types.QueueAttributeNameApproximateNumberOfMessagesDelayed,
+		},
+	})
+	if err != nil {
+		return queueAttr{}, err
+	}
+	return queueAttr{
+		Visible:  atoi(out.Attributes["ApproximateNumberOfMessages"]),
+		InFlight: atoi(out.Attributes["ApproximateNumberOfMessagesNotVisible"]),
+		Delayed:  atoi(out.Attributes["ApproximateNumberOfMessagesDelayed"]),
+	}, nil
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,17 +9,21 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
+	lab := e.Group("/api/lab")
 	if labS3Handler != nil {
-		lab := e.Group("/api/lab")
 		lab.GET("/s3/objects", labS3Handler.ListObjects)
 		lab.POST("/s3/multipart/create", labS3Handler.CreateMultipart)
 		lab.POST("/s3/multipart/sign-part", labS3Handler.SignPart)
 		lab.POST("/s3/multipart/complete", labS3Handler.CompleteMultipart)
 		lab.POST("/s3/multipart/abort", labS3Handler.AbortMultipart)
+	}
+	if labSQSHandler != nil {
+		lab.POST("/sqs/publish", labSQSHandler.Publish)
+		lab.GET("/sqs/stats", labSQSHandler.Stats)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
> ⚠️ **stacked PR**: base は `feature/lab-s3-multipart`（#73）。#73 マージ後に base を develop に付け替えてください。

## 実装概要

Lab 第 2 弾。SQS キューに publish する API と、`lab-primary` を long polling で消費する **別プロセスの worker** を追加。worker は `cmd/worker` にあり、docker-compose.lab.yml の `worker` サービスとして backend と同じ image を使い command を差し替えて起動する。DLQ の redrive policy も併せて設定し、"fail" を含むメッセージが 3 回再配信後に DLQ に移動する挙動を観察できる。

### 追加ファイル

- `src/handlers/lab_sqs_handler.go` — publish / stats の 2 エンドポイント
- `cmd/worker/main.go` — long polling ワーカー本体（20 秒 WaitTime、10 秒 VisibilityTimeout）

### 変更ファイル

- `src/routes/routes.go` / `main.go` — `LabSQSHandler` を初期化し `/api/lab/sqs/*` を登録
- `Dockerfile` — `go build -o worker ./cmd/worker` を追加し同一 image に 2 バイナリ同梱
- `docker-compose.lab.yml` — `worker` サービス（`command: ["./worker"]`）と backend への SQS URL env を追加
- `scripts/init-localstack.sh` — `lab-primary → lab-dlq` の redrive policy (maxReceiveCount=3) を設定
- `CLAUDE.md` — API 一覧・ディレクトリ構造・環境変数を更新

### エンドポイント

| method | path | 役割 |
|---|---|---|
| POST | `/api/lab/sqs/publish` | `lab-primary` にメッセージ送信、messageId を返す |
| GET  | `/api/lab/sqs/stats` | `lab-primary` / `lab-dlq` の概算メッセージ数（visible / inFlight / delayed） |

## 設計判断の「なぜ」

### なぜ worker を別プロセス（別コンテナ）にしたか

候補:

| 方式 | 長所 | 短所 |
|---|---|---|
| A. backend 内の goroutine | 実装最小、env 共有 | HTTP トラフィックと同 Pod、ReceiveMessage のブロッキングが他リクエストに影響し得る、スケーリング単位が固定 |
| **B. 別バイナリ・別コンテナ（本 PR）** | 本番で定石、API と Worker で独立スケール、落ちても他方に影響しない | ビルド / デプロイが 2 つ |
| C. AWS Lambda SQS trigger | インフラ不要、自動スケール | cold start / 14 分制限 / 長時間処理に向かない |

本番で SQS worker を運用する典型例は B。API Pod は HTTP RPS でスケール、Worker Pod は queue depth でスケールする（HPA 指定を分ける）。lab でもこの構造を再現するため B を選んだ。**同一 image に 2 バイナリを入れて command で切替** する方式はシンプルで、CI/CD も 1 本で済むためよく採用される（kubernetes の同 Deployment で違う command の Container を持つパターンと同型）。

### なぜ `WaitTimeSeconds: 20`（long polling）か

short polling (0) で ReceiveMessage を連打すると、**メッセージが無い時も HTTP リクエストごとに課金される** (本番 SQS)。long polling なら 20 秒待っても 1 リクエスト分の課金で済む。AWS 推奨は 20 秒。lab でも同じ挙動を採用。

### なぜ `VisibilityTimeout: 10` か

本来は「処理時間の最大値より十分長く」設定する（AWS 推奨は処理時間 × 3〜5）。lab では「fail 時の再配信を観察しやすくする」ため意図的に短くしている。本番なら実処理時間（P99）の数倍を目安にする。

### なぜ redrive policy を 3 にしたか

`maxReceiveCount` は「何回受信されたら DLQ 送り」の閾値。典型は 3〜5。1 だと単なる失敗で DLQ 行きになりノイズが多い、10 以上だと転送遅延が大きくなる。バランスの 3。

### なぜ `Publish` で body 空チェックをしているか

SQS の API 仕様上、空文字の MessageBody は **許可されている**（bytes=0 の送信も可）。ただし実運用でゴミが流れると調査が面倒なので、API 境界で 400 を返すほうが親切。これは lab だけど本番でも同じ作法でいい。

## ハマりポイント・注意事項

### 1. redrive policy の JSON エスケープ

`RedrivePolicy` は **JSON 文字列を JSON の値** として渡す必要がある（属性値がさらに JSON）ので、shell で直接書くとエスケープが地獄になる。本 PR では `cat > /tmp/sqs-redrive.json <<EOF` で中間ファイルを経由し、`awscli` に `file://` で読ませることで回避した。

### 2. visibility timeout と「メッセージの削除忘れ」

DeleteMessage を呼ばないと自動的に再配信される。最初のうちは「メッセージが消えない、なぜ？」で悩みがち。デバッグ時は visibility timeout を短くするか、コード上で明示的に delete を呼んでいるか確認する。

### 3. 複数 worker 同時処理時の idempotency

本 PR の worker は 1 インスタンスだけ動かしているが、本番で worker を 2〜N 台並べると、稀に「visibility timeout 内に処理が終わらない」ケースで **同じメッセージが 2 回処理される** ことがある。SQS は at-least-once なので idempotency を処理側で担保するのが原則（処理結果を DB に書くなら unique 制約、外部 API を叩くなら idempotency key）。

### 4. ApproximateNumberOfMessages の結果整合性

`GetQueueAttributes` で返る値は概算値で、send / receive 直後は数秒の遅延がある。stats API を毎秒ポーリングすると値がぶれて見えることがある。本 PR の UI も 2 秒間隔にしている。

### 5. 同じ image に 2 バイナリ同梱のコスト

Dockerfile で `go build -o main . && go build -o worker ./cmd/worker` としているため、どちらの pod もイメージサイズは同じ。別々の minimal image にするとイメージサイズは小さくなるが、CI と registry 管理が 2 倍になる。本番でも「small binary × 2 image」より「1 image で command 切替」のほうが運用が楽で広く採用されている。

## 本番 AWS との差分・設定箇所

| 項目 | ローカル (LocalStack) | 本番 AWS |
|---|---|---|
| Queue 作成 | `awslocal sqs create-queue` | Terraform `aws_sqs_queue` |
| Redrive policy | `init-localstack.sh` で設定 | Terraform `aws_sqs_queue.redrive_policy` |
| Queue URL | `http://localstack:4566/000000000000/lab-primary` | `https://sqs.ap-northeast-1.amazonaws.com/<account>/prod-xxx` |
| 認証 | `AWS_ACCESS_KEY_ID=test` 等 | IAM Role（ECS Task Role / IRSA）で自動注入 |
| Monitoring | なし | CloudWatch で `ApproximateAgeOfOldestMessage` / `NumberOfMessagesVisible` をアラート |
| DLQ 監視 | UI 上で可視 | `NumberOfMessagesVisible > 0` を Slack / PagerDuty に通知 |
| Worker のデプロイ | docker-compose で同居 | ECS Service / k8s Deployment の別単位。queue depth ベースで HPA/TargetTracking |

### Terraform 最小セット

```hcl
resource "aws_sqs_queue" "primary" {
  name                       = "prod-primary"
  visibility_timeout_seconds = 60
  redrive_policy = jsonencode({
    deadLetterTargetArn = aws_sqs_queue.dlq.arn
    maxReceiveCount     = 3
  })
}

resource "aws_sqs_queue" "dlq" {
  name                      = "prod-dlq"
  message_retention_seconds = 1209600 # 14d (最大)
}

resource "aws_cloudwatch_metric_alarm" "dlq_has_messages" {
  alarm_name          = "sqs-dlq-has-messages"
  metric_name         = "ApproximateNumberOfMessagesVisible"
  namespace           = "AWS/SQS"
  dimensions          = { QueueName = aws_sqs_queue.dlq.name }
  threshold           = 0
  comparison_operator = "GreaterThanThreshold"
  evaluation_periods  = 1
  period              = 60
  statistic           = "Maximum"
  alarm_actions       = [aws_sns_topic.alerts.arn]
}
```

## 面接で話せるポイント

- **なぜ API Pod と Worker Pod を分けるか**: スケーリング戦略の違い (RPS vs queue depth)、障害ドメイン分離、デプロイ独立性
- **at-most-once / at-least-once / exactly-once**: SQS は標準キューで at-least-once。exactly-once 風にしたければ FIFO キュー (ただし 300 msg/s の上限) または消費側で idempotency を実装
- **long polling を使わない場合の課金**: 空ポーリングごとに 0.0004 USD/1M requests が積み重なる。月数万ドル溶ける話も実在する
- **visibility timeout の設計**: 短いと二重処理、長いと障害時復旧が遅れる。P99 処理時間 × 3 が目安
- **DLQ に来た時の運用**: 「DLQ に来た = 自動復旧できなかった」なので、原因調査 → 修正 → メッセージ re-drive（最近 SQS に standard redrive が入って楽になった）の手順
- **backpressure**: queue depth が閾値を超えたら書き込み側にリトライ要求を返す or producer を絞る。SQS 自体は backpressure を提供しないので、アプリ層で実装
- **exactly-once と冪等性の違い**: exactly-once は配送の話、冪等性は処理側の性質。普通は後者で解決するほうが安い

## Test plan

- [x] `make up-lab` で `worker` が起動し long polling を開始
- [x] `curl -X POST /api/lab/sqs/publish -d '{"body":"hello"}'` → messageId 返る
- [x] `curl /api/lab/sqs/stats` で `primary.visible` 増減を確認
- [x] 通常メッセージ 3 通を送る → worker logs に `received` → `processed` が並ぶ → stats が 0 に戻る
- [x] `body: "fail"` を含むメッセージを送る → 10 秒ごとに再配信 3 回 → DLQ に 1 件移動
- [x] `docker compose ... logs worker` で simulated failure の流れが追える
- [ ] ブラウザ (`/lab/queue`) からの E2E は fanc-front 側 PR で確認

### 関連 PR

- Frontend: fanc-front 側で `/lab/queue` UI を実装（別 PR）
- Depends on: #73 (AWS SDK 導入、Go 1.24 bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
