### PR TITLE
feat(lab): SNS → SQS fanout の API / worker を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,12 +70,14 @@ db/
   - `GET  /api/lab/s3/objects` — アップロード済みファイル一覧
   - `POST /api/lab/sqs/publish` — lab-primary へメッセージ送信
   - `GET  /api/lab/sqs/stats` — primary / dlq の概算メッセージ数
+  - `POST /api/lab/sns/publish` — lab-events topic に publish → lab-primary / lab-audit へ fanout
+  - `GET  /api/lab/sns/stats` — primary / audit の概算メッセージ数
 
-lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。`lab-primary` を long polling で受信し、"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動を観察できる。
+lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。1 プロセス内で **2 goroutine が primary / audit を独立に long polling** する構造で、SNS → SQS fanout の両キュー同時消費を観察できる。"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動も観察可能。
 
-  方式選択の背景（A=backend 経由 / B=presigned single PUT / C=multipart）は
-  `~/.claude/docs/interview/system-design/file-upload-patterns.md` を参照。
-  本 lab は B2B SaaS 想定で B を採用。
+  ナレッジ集:
+  - ファイルアップロード方式 (A/B/C): `~/.claude/docs/interview/system-design/file-upload-patterns.md`
+  - SQS 運用ノウハウ（VisibilityTimeout / DLQ / スケール）: `~/.claude/docs/interview/system-design/sqs-essentials.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 
@@ -91,7 +93,8 @@ main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 �
   - `AWS_PUBLIC_ENDPOINT_URL` — ブラウザ向け presigned URL 生成用 (`http://localhost:4566`)
   - `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
   - `LAB_S3_BUCKET`（既定 `lab-uploads`）
-  - `LAB_SQS_PRIMARY_URL`, `LAB_SQS_DLQ_URL`
+  - `LAB_SQS_PRIMARY_URL`, `LAB_SQS_AUDIT_URL`, `LAB_SQS_DLQ_URL`
+  - `LAB_SNS_TOPIC_ARN`（既定 `arn:aws:sns:ap-northeast-1:000000000000:lab-events`）
   - `POSTGRES_DSN`, `REDIS_ADDR`
 
 ## CI/CD

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,7 +1,9 @@
 // Package main は lab 用の SQS worker バイナリ。
-// docker-compose.lab.yml の worker サービスで起動し、lab-primary を long polling する。
+// docker-compose.lab.yml の worker サービスで起動し、lab-primary / lab-audit を
+// long polling する。1 プロセス内で 2 goroutine が別キューを独立に消費する構造で、
+// SNS → SQS fanout の両キュー同時消費を観察できる。
 // メッセージ本文に "fail" を含む場合は DeleteMessage を呼ばず、visibility timeout 切れ
-// による再配信を発生させる（redrive policy により maxReceiveCount 到達で DLQ に移る）。
+// による再配信を発生させる（primary の redrive policy により maxReceiveCount 到達で DLQ に移る）。
 package main
 
 import (
@@ -10,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -35,36 +38,54 @@ func main() {
 		}
 	})
 
-	queueURL := getenv("LAB_SQS_PRIMARY_URL", "http://localstack:4566/000000000000/lab-primary")
-	log.Printf("worker: starting, polling %s", queueURL)
+	queues := []struct {
+		label string
+		url   string
+	}{
+		{"primary", getenv("LAB_SQS_PRIMARY_URL", "http://localstack:4566/000000000000/lab-primary")},
+		{"audit", getenv("LAB_SQS_AUDIT_URL", "http://localstack:4566/000000000000/lab-audit")},
+	}
 
+	var wg sync.WaitGroup
+	for _, q := range queues {
+		wg.Add(1)
+		go func(label, url string) {
+			defer wg.Done()
+			pollLoop(ctx, client, label, url)
+		}(q.label, q.url)
+	}
+	wg.Wait()
+	log.Println("worker: shutdown")
+}
+
+// pollLoop は 1 キュー分の long polling ループ。SIGTERM で ctx がキャンセルされるまで回る。
+func pollLoop(ctx context.Context, client *sqs.Client, label, queueURL string) {
+	log.Printf("[%s] worker starting, polling %s", label, queueURL)
 	for ctx.Err() == nil {
 		out, err := client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
 			QueueUrl:            aws.String(queueURL),
 			MaxNumberOfMessages: 10,
 			// long polling: メッセージが無ければ最大 20 秒サーバー側で待つ
-			// 空ポーリングによる無駄なリクエストと料金を抑える基本設定
 			WaitTimeSeconds: 20,
 			// 処理中は他 worker から見えないようにする。この時間内に DeleteMessage
-			// を呼ばないと再配信される（失敗扱い）
+			// を呼ばないと再配信される
 			VisibilityTimeout: 10,
 		})
 		if err != nil {
 			if ctx.Err() != nil {
-				break
+				return
 			}
-			log.Printf("receive error: %v", err)
+			log.Printf("[%s] receive error: %v", label, err)
 			time.Sleep(1 * time.Second)
 			continue
 		}
 		for _, msg := range out.Messages {
 			body := aws.ToString(msg.Body)
-			log.Printf("worker: received: %s", body)
-			// ダミー処理（1 秒のウェイト）
-			time.Sleep(1 * time.Second)
+			log.Printf("[%s] received: %s", label, body)
+			time.Sleep(1 * time.Second) // ダミー処理
 
 			if strings.Contains(body, "fail") {
-				log.Printf("worker: simulated failure for %q — skipping delete → redelivery", body)
+				log.Printf("[%s] simulated failure for %q — skipping delete → redelivery", label, body)
 				continue
 			}
 
@@ -73,13 +94,12 @@ func main() {
 				ReceiptHandle: msg.ReceiptHandle,
 			})
 			if err != nil {
-				log.Printf("delete error: %v", err)
+				log.Printf("[%s] delete error: %v", label, err)
 				continue
 			}
-			log.Printf("worker: processed: %s", body)
+			log.Printf("[%s] processed: %s", label, body)
 		}
 	}
-	log.Println("worker: shutdown")
 }
 
 func getenv(key, fallback string) string {

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -19,7 +19,9 @@ services:
       POSTGRES_DSN: postgres://lab:lab@postgres:5432/lab?sslmode=disable
       REDIS_ADDR: redis:6379
       LAB_SQS_PRIMARY_URL: http://localstack:4566/000000000000/lab-primary
+      LAB_SQS_AUDIT_URL: http://localstack:4566/000000000000/lab-audit
       LAB_SQS_DLQ_URL: http://localstack:4566/000000000000/lab-dlq
+      LAB_SNS_TOPIC_ARN: arn:aws:sns:ap-northeast-1:000000000000:lab-events
     depends_on:
       - mysql
       - localstack
@@ -66,6 +68,7 @@ services:
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
       LAB_SQS_PRIMARY_URL: http://localstack:4566/000000000000/lab-primary
+      LAB_SQS_AUDIT_URL: http://localstack:4566/000000000000/lab-audit
     depends_on:
       - localstack
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1
+	github.com/aws/aws-sdk-go-v2/service/sns v1.39.16
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-playground/validator/v10 v10.13.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1 h1:kU/eBN5+MWNo/LcbNa4hWDdN76hdc
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1/go.mod h1:Fw9aqhJicIVee1VytBBjH+l+5ov6/PhbtIK/u3rt/ls=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10 h1:a1Fq/KXn75wSzoJaPQTgZO0wHGqE9mjFnylnqEPTchA=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.10/go.mod h1:p6+MXNxW7IA6dMgHfTAzljuwSKD0NCm/4lbS4t6+7vI=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.16 h1:CIFDzcrpG87cjj5Op1NZ55BZV64mFka1DuJIEjedxmI=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.16/go.mod h1:468X50NBvl50h/poFrQXD1oZMxbOCTQSVdvowm0i4aw=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26 h1:jtUEQz/c14fCMkOX3r2/nhYmhXZas0XdcQhUaIW5ubY=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.26/go.mod h1:gcJv70rH+Z/Q1PM3jKsJr6+vfKrDHJOfmKq7342+Vq8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.16 h1:x6bKbmDhsgSZwv6q19wY/u3rLk/3FGjJWyqKcIRufpE=

--- a/main.go
+++ b/main.go
@@ -64,8 +64,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab sqs handler init failed, /api/lab/sqs/* disabled: %s", err.Error())
 	}
+	labSNSHandler, err := handlers.NewLabSNSHandler()
+	if err != nil {
+		e.Logger.Warnf("lab sns handler init failed, /api/lab/sns/* disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler)
 
 	e.Start(":8080")
 }

--- a/src/handlers/lab_sns_handler.go
+++ b/src/handlers/lab_sns_handler.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/labstack/echo/v4"
+)
+
+// LabSNSHandler は SNS → SQS fanout の publish と 2 つのキューの stats を提供する。
+// 1 回の SNS Publish で lab-primary / lab-audit の両方にメッセージがコピーされる様子を
+// UI から観察できるようにするのが目的。
+type LabSNSHandler struct {
+	snsClient   *sns.Client
+	sqsClient   *sqs.Client
+	topicARN    string
+	primaryURL  string
+	auditURL    string
+}
+
+// NewLabSNSHandler は LocalStack 前提で SNS / SQS クライアントを初期化する。
+func NewLabSNSHandler() (*LabSNSHandler, error) {
+	ctx := context.Background()
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(getenv("AWS_REGION", "ap-northeast-1")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	snsClient := sns.NewFromConfig(cfg, func(o *sns.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+	})
+	sqsClient := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+	})
+
+	return &LabSNSHandler{
+		snsClient:  snsClient,
+		sqsClient:  sqsClient,
+		topicARN:   getenv("LAB_SNS_TOPIC_ARN", "arn:aws:sns:ap-northeast-1:000000000000:lab-events"),
+		primaryURL: getenv("LAB_SQS_PRIMARY_URL", "http://localstack:4566/000000000000/lab-primary"),
+		auditURL:   getenv("LAB_SQS_AUDIT_URL", "http://localstack:4566/000000000000/lab-audit"),
+	}, nil
+}
+
+type snsPublishReq struct {
+	Body string `json:"body"`
+}
+
+type snsPublishRes struct {
+	MessageID string `json:"messageId"`
+}
+
+// PublishToTopic は SNS topic にメッセージを publish する。
+// subscribe されている全 SQS キュー（lab-primary / lab-audit）に同じメッセージが配信される。
+func (h *LabSNSHandler) PublishToTopic(c echo.Context) error {
+	var req snsPublishReq
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if req.Body == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "body required")
+	}
+	out, err := h.snsClient.Publish(c.Request().Context(), &sns.PublishInput{
+		TopicArn: aws.String(h.topicARN),
+		Message:  aws.String(req.Body),
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, snsPublishRes{MessageID: aws.ToString(out.MessageId)})
+}
+
+type fanoutQueueStat struct {
+	Name     string `json:"name"`
+	Visible  int    `json:"visible"`
+	InFlight int    `json:"inFlight"`
+}
+
+type fanoutStatsRes struct {
+	Queues []fanoutQueueStat `json:"queues"`
+}
+
+// FanoutStats は primary / audit の概算件数を返す。
+// publish 直後に両方の visible が +1 されることで fanout の挙動を確認する。
+func (h *LabSNSHandler) FanoutStats(c echo.Context) error {
+	ctx := c.Request().Context()
+	queues := []struct {
+		name string
+		url  string
+	}{
+		{"lab-primary", h.primaryURL},
+		{"lab-audit", h.auditURL},
+	}
+	stats := make([]fanoutQueueStat, 0, len(queues))
+	for _, q := range queues {
+		out, err := h.sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+			QueueUrl: aws.String(q.url),
+			AttributeNames: []types.QueueAttributeName{
+				types.QueueAttributeNameApproximateNumberOfMessages,
+				types.QueueAttributeNameApproximateNumberOfMessagesNotVisible,
+			},
+		})
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, q.name+": "+err.Error())
+		}
+		stats = append(stats, fanoutQueueStat{
+			Name:     q.name,
+			Visible:  atoi(out.Attributes["ApproximateNumberOfMessages"]),
+			InFlight: atoi(out.Attributes["ApproximateNumberOfMessagesNotVisible"]),
+		})
+	}
+	return c.JSON(http.StatusOK, fanoutStatsRes{Queues: stats})
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -21,6 +21,10 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 	if labSQSHandler != nil {
 		lab.POST("/sqs/publish", labSQSHandler.Publish)
 		lab.GET("/sqs/stats", labSQSHandler.Stats)
+	}
+	if labSNSHandler != nil {
+		lab.POST("/sns/publish", labSNSHandler.PublishToTopic)
+		lab.GET("/sns/stats", labSNSHandler.FanoutStats)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
## 実装概要

lab 第 3 弾。SNS topic (`lab-events`) への 1 回の `Publish` で subscribe されている 2 つの SQS キュー（`lab-primary` / `lab-audit`）に同じメッセージが配信される **fanout 構成**を API + worker で実装。

- **publish API**: `POST /api/lab/sns/publish` → SNS に流し込み
- **stats API**: `GET /api/lab/sns/stats` → primary / audit 両方の件数を返す
- **worker**: 1 プロセス内で **2 goroutine** が各キューを独立に long polling（別々にスケール可能な構造を再現）

### 変更ファイル

- `src/handlers/lab_sns_handler.go` — 新規。`PublishToTopic` / `FanoutStats`
- `src/routes/routes.go` — `/api/lab/sns/publish`, `/api/lab/sns/stats` 登録
- `main.go` — `LabSNSHandler` 初期化
- `cmd/worker/main.go` — `pollLoop` 関数に抽出、primary / audit の 2 goroutine を sync.WaitGroup で管理
- `docker-compose.lab.yml` — `LAB_SQS_AUDIT_URL` / `LAB_SNS_TOPIC_ARN` env 追加
- `CLAUDE.md` — API 一覧・worker 構造・環境変数を更新

### エンドポイント

| method | path | 役割 |
|---|---|---|
| POST | `/api/lab/sns/publish` | `lab-events` topic にメッセージを publish。`lab-primary` / `lab-audit` の両方に届く |
| GET | `/api/lab/sns/stats` | `lab-primary` / `lab-audit` の concurrent な件数 |

## 設計判断の「なぜ」

### なぜ SNS → SQS fanout か（SNS 直接配信ではなく）

候補:

| 方式 | 向いているケース |
|---|---|
| **SNS → SQS fanout（本 PR）** | キュー単位で独立にスケール・再処理したい。メッセージを「後で」処理したい。at-least-once と DLQ で信頼性を担保 |
| SNS → Lambda | イベント数が少ない、serverless でいい、同期的な単発処理 |
| SNS → HTTP(s) endpoint | 外部サービスへ通知。ただしリトライ制約があるため社内システム間では SQS 経由を推奨 |
| EventBridge | スキーマ/フィルタ/multi-account を跨ぐルーティング。SNS より高機能だが料金も高い |

B2B SaaS で「**同じイベントを複数の subsystem が独立に消費する**」典型ケース（例: 請求書登録 → 会計処理 / 通知送信 / 監査ログ）には SNS → SQS fanout が最もシンプル。SQS 側に DLQ / redrive / 個別スケールを持たせられる。

### なぜ worker を 1 プロセス × 2 goroutine に？

候補:

| 方式 | 長所 | 短所 |
|---|---|---|
| **A. 1 プロセス × N goroutine（本 PR）** | 運用単位が少ない、起動コスト低、goroutine 間でコネクションプール共有可能 | 障害ドメインが 1 つ（1 goroutine の panic が全体に波及する可能性あり） |
| B. キューごとに別プロセス（別コンテナ） | 障害ドメイン分離、キュー別に独立デプロイ可能、独立スケール | 運用単位・イメージ数が増える、起動オーバーヘッド |

本 lab は **A（1 プロセス × 2 goroutine）** を採用。理由:
- キューの種類が少ない（2 つ）。本番で 10 キューある場合は B を検討
- goroutine は panic を recover できる構造にすれば障害ドメインも分離可能
- スケールしたい場合も「Pod 数を増やす」で両キュー両方スケールする

現実の B2B SaaS だと「共通の前処理 + ドメイン別 worker」なら A、完全に別チームが触るなら B、という使い分け。

### なぜ `RawMessageDelivery=true` か

SNS から SQS に流すと、デフォルトでは **SNS エンベロープ**に包まれて届く:

```json
{
  "Type": "Notification",
  "MessageId": "...",
  "TopicArn": "...",
  "Message": "hello"   ← これが元のメッセージ
}
```

`RawMessageDelivery=true` を設定すると、**素の body がそのまま SQS に入る**。受信側が envelope をパースする必要がなく、既存の SQS 直接受信コードと互換性が保てる。init-localstack.sh で設定済み。

本番でも `RawMessageDelivery=true` がほぼ必須。

### なぜ `sync.WaitGroup` で 2 goroutine を管理しているか

shutdown 時に「primary 側が処理中で audit 側が早く終わる」ケースがある。WaitGroup で両方の `pollLoop` 完了を待ってから main が return することで、graceful shutdown を保証する。

## ハマりポイント・注意事項

### 1. SNS topic ARN は環境変数で渡す

本番で `arn:aws:sns:ap-northeast-1:<account>:prod-events` のように account / region が動的になるため、コードにハードコードしない。lab では既定値として LocalStack の fixed な値を使用。

### 2. RawMessageDelivery を忘れると SQS 受信コードが envelope を意識する必要がある

消費側のコードを SNS-agnostic に保つためには必須。DLQ やキュー直接 publish のパスでも同じコードが使えるようにする。

### 3. fanout 先キューの数を増やしたい時

`scripts/init-localstack.sh` の `awslocal sns subscribe` を追加するだけで済む。コード変更不要（消費側に worker を追加するだけ）。

## 本番 AWS との差分・設定箇所

| 項目 | ローカル (LocalStack) | 本番 AWS |
|---|---|---|
| Topic 作成 | `awslocal sns create-topic` | Terraform `aws_sns_topic` |
| Subscribe | `awslocal sns subscribe` | Terraform `aws_sns_topic_subscription` (`raw_message_delivery = true`) |
| Topic ARN | `arn:aws:sns:ap-northeast-1:000000000000:lab-events` | 実 account ID が入る。`LAB_SNS_TOPIC_ARN` で注入 |
| IAM | なし | SNS topic policy で「SQS への配信を許可」、SQS queue policy で「SNS からの受信を許可」を両方設定 |

### Terraform 最小セット

```hcl
resource "aws_sns_topic" "events" {
  name = "prod-events"
}

resource "aws_sqs_queue" "primary" { name = "prod-primary" }
resource "aws_sqs_queue" "audit"   { name = "prod-audit" }

resource "aws_sns_topic_subscription" "primary" {
  topic_arn            = aws_sns_topic.events.arn
  protocol             = "sqs"
  endpoint             = aws_sqs_queue.primary.arn
  raw_message_delivery = true
}
resource "aws_sns_topic_subscription" "audit" {
  topic_arn            = aws_sns_topic.events.arn
  protocol             = "sqs"
  endpoint             = aws_sqs_queue.audit.arn
  raw_message_delivery = true
}

# SQS queue policy: SNS からの送信を許可
resource "aws_sqs_queue_policy" "primary" {
  queue_url = aws_sqs_queue.primary.id
  policy = jsonencode({
    Statement = [{
      Effect    = "Allow"
      Principal = { Service = "sns.amazonaws.com" }
      Action    = "sqs:SendMessage"
      Resource  = aws_sqs_queue.primary.arn
      Condition = { ArnEquals = { "aws:SourceArn" = aws_sns_topic.events.arn } }
    }]
  })
}
```

## 面接で話せるポイント

- **SNS → SQS fanout を選ぶ基準**: 複数の subsystem が独立に消費、各 subsystem に独立 DLQ / リトライ / スケールが欲しい
- **なぜ EventBridge ではなく SNS か**: SNS のほうが安くシンプル。schema registry / cross-account / complex filter が不要なら SNS 十分
- **fanout と Pub/Sub の違い**: fanout は SNS のトポロジ。Pub/Sub は概念。「同一メッセージを複数コンシューマが独立に消費」する実装が fanout
- **order 保証**: 標準 SNS → 標準 SQS は順序保証なし。必要なら FIFO topic + FIFO queue（秒間 300 上限あり）
- **idempotency**: at-least-once なので各 SQS 消費側で冪等性を担保（メッセージ ID ベースの重複排除）
- **filter policy**: SNS subscription に filter を付ければ「audit だけ特定タイプのイベントを受信」などが可能。ただし複雑化するので `EventBridge` との選択分岐点になる

## Test plan

- [x] `make rebuild` で backend / worker が再ビルド起動
- [x] `curl /api/lab/sns/stats` → `lab-primary` / `lab-audit` がそれぞれ 0
- [x] `curl -X POST /api/lab/sns/publish -d '{"body":"hello"}'` → messageId 返る
- [x] `docker logs fanc-api-worker-1` で `[primary] received` と `[audit] received` が両方出る
- [x] stats で両キューの visible が +1 → 処理完了後 0 に戻る
- [ ] ブラウザ (`/lab/fanout`) からの E2E は fanc-front 側 PR で確認

### 関連 PR

- Frontend: `fanc-front feature/lab-sns-fanout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
