### PR TITLE
feat(lab): S3 PUT → Go Lambda → results/*.json の lab を追加

### DIFF
--- a/cmd/lambda/Dockerfile
+++ b/cmd/lambda/Dockerfile
@@ -1,0 +1,25 @@
+# lab 用 Lambda のビルド + LocalStack へのデプロイ用イメージ。
+# 1. ビルドステージで Go Lambda バイナリ (provided.al2 runtime 用に bootstrap と命名) を作る
+# 2. デプロイステージは awslocal を持ち、bootstrap を zip して LocalStack に上げ、
+#    lab-lambda バケットに S3 イベント通知を設定する。
+# docker-compose.lab.yml の lambda-deployer サービスが利用する。
+
+FROM golang:1.24 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/lambda cmd/lambda
+# provided.al2 の entrypoint は /var/runtime/bootstrap。
+# zip のルート直下に "bootstrap" を置く必要がある。
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /out/bootstrap ./cmd/lambda
+
+FROM python:3.11-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends zip ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir awscli awscli-local
+COPY --from=build /out/bootstrap /workspace/bootstrap
+COPY scripts/deploy-lambda.sh /workspace/deploy-lambda.sh
+RUN chmod +x /workspace/deploy-lambda.sh
+WORKDIR /workspace
+CMD ["/workspace/deploy-lambda.sh"]

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -1,0 +1,133 @@
+// Package main は lab 用の S3 → Lambda トリガー処理バイナリ。
+// LocalStack 上で provided.al2 runtime として実行される。
+// lab-lambda バケットの uploads/ 配下に PutObject されるとこの Lambda が呼ばれ、
+// 対象オブジェクトを GetObject → SHA-256・サイズ・ContentType を計算し、
+// 同バケット results/ 配下に JSON として書き戻す。
+//
+// 無限ループ防止のため、S3 側のイベント通知は prefix=uploads/ でフィルタしているので
+// results/ への PutObject では再発火しない（deploy-lambda.sh 参照）。
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// result は Lambda が uploads/ のオブジェクトを処理して results/*.json に書き戻す内容。
+type result struct {
+	Key         string    `json:"key"`
+	Bucket      string    `json:"bucket"`
+	Size        int64     `json:"size"`
+	ContentType string    `json:"contentType"`
+	SHA256      string    `json:"sha256"`
+	ProcessedAt time.Time `json:"processedAt"`
+}
+
+// handler は S3 イベントの各 record を順に処理する。
+func handler(ctx context.Context, evt events.S3Event) error {
+	client, err := newS3Client(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range evt.Records {
+		bucket := r.S3.Bucket.Name
+		key := r.S3.Object.Key
+		log.Printf("event: s3://%s/%s", bucket, key)
+
+		// 念のためのガード（イベント通知側で prefix=uploads/ を効かせているが、
+		// 誤って results/ が入ってきたときに自己再帰で料金事故にならないよう二重防御）。
+		if strings.HasPrefix(key, "results/") {
+			log.Printf("skip self-generated result object: %s", key)
+			continue
+		}
+
+		if err := processOne(ctx, client, bucket, key); err != nil {
+			return fmt.Errorf("process %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func processOne(ctx context.Context, client *s3.Client, bucket, key string) error {
+	out, err := client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return fmt.Errorf("get object: %w", err)
+	}
+	defer out.Body.Close()
+
+	data, err := io.ReadAll(out.Body)
+	if err != nil {
+		return fmt.Errorf("read body: %w", err)
+	}
+
+	sum := sha256.Sum256(data)
+	body, err := json.MarshalIndent(result{
+		Key:         key,
+		Bucket:      bucket,
+		Size:        int64(len(data)),
+		ContentType: aws.ToString(out.ContentType),
+		SHA256:      hex.EncodeToString(sum[:]),
+		ProcessedAt: time.Now().UTC(),
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal result: %w", err)
+	}
+
+	resultKey := "results/" + strings.TrimPrefix(key, "uploads/") + ".json"
+	if _, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(resultKey),
+		Body:        bytes.NewReader(body),
+		ContentType: aws.String("application/json"),
+	}); err != nil {
+		return fmt.Errorf("put result: %w", err)
+	}
+	log.Printf("wrote: s3://%s/%s (size=%d)", bucket, resultKey, len(data))
+	return nil
+}
+
+// newS3Client は LocalStack 内の Lambda ランタイム上で S3 を呼べるクライアントを返す。
+// LocalStack では Lambda コンテナに LOCALSTACK_HOSTNAME (または AWS_ENDPOINT_URL) が
+// 注入される。本番 AWS ではこれらを設定しないので endpoint override は効かず、
+// 通常通り AWS 公開エンドポイントに向く。
+func newS3Client(ctx context.Context) (*s3.Client, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+	endpoint := os.Getenv("AWS_ENDPOINT_URL")
+	if endpoint == "" {
+		if h := os.Getenv("LOCALSTACK_HOSTNAME"); h != "" {
+			endpoint = "http://" + h + ":4566"
+		}
+	}
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+			o.UsePathStyle = true
+		}
+	}), nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -22,6 +22,7 @@ services:
       LAB_SQS_AUDIT_URL: http://localstack:4566/000000000000/lab-audit
       LAB_SQS_DLQ_URL: http://localstack:4566/000000000000/lab-dlq
       LAB_SNS_TOPIC_ARN: arn:aws:sns:ap-northeast-1:000000000000:lab-events
+      LAB_LAMBDA_BUCKET: lab-lambda
     depends_on:
       - mysql
       - localstack
@@ -71,6 +72,24 @@ services:
       LAB_SQS_AUDIT_URL: http://localstack:4566/000000000000/lab-audit
     depends_on:
       - localstack
+
+  # lab 用 Lambda デプロイの一回限りサービス。
+  # Go Lambda を build → zip → LocalStack に create-function → S3 イベント通知設定、
+  # を実行してから exit する (restart: "no")。
+  # init-localstack.sh に寄せなかったのは、LocalStack 本体コンテナに Go ツールチェインを
+  # 持ち込みたくないため (docker-compose 側で builder stage 分離する方がクリーン)。
+  lambda-deployer:
+    build:
+      context: .
+      dockerfile: cmd/lambda/Dockerfile
+    environment:
+      AWS_ENDPOINT_URL: http://localstack:4566
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    depends_on:
+      - localstack
+    restart: "no"
 
 volumes:
   postgres-lab-data:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module fanc-api
 go 1.24
 
 require (
+	github.com/aws/aws-lambda-go v1.54.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
+github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
 github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 h1:adBsCIIpLbLmYnkQU+nAChU5yhVTvu5PerROm+/Kq2A=

--- a/main.go
+++ b/main.go
@@ -68,8 +68,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab sns handler init failed, /api/lab/sns/* disabled: %s", err.Error())
 	}
+	labLambdaHandler, err := handlers.NewLabLambdaHandler()
+	if err != nil {
+		e.Logger.Warnf("lab lambda handler init failed, /api/lab/lambda/* disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler)
 
 	e.Start(":8080")
 }

--- a/scripts/deploy-lambda.sh
+++ b/scripts/deploy-lambda.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# lab 用 Go Lambda を LocalStack にデプロイして、lab-lambda バケットに
+# uploads/ prefix の PutObject → Lambda 呼び出しの S3 イベント通知を設定する。
+# docker-compose.lab.yml の lambda-deployer 一回限りサービスから実行される。
+set -e
+
+FUNCTION_NAME=lab-s3-processor
+BUCKET=lab-lambda
+# LocalStack では IAM をモックするため、role ARN の実在性は問われない。
+# 本番では Lambda 実行ロール（logs:CreateLogGroup / s3:GetObject / s3:PutObject 等）を作成する。
+ROLE_ARN=arn:aws:iam::000000000000:role/lambda-role
+
+echo "[deploy-lambda] waiting for localstack..."
+# init-localstack.sh で lab-lambda バケットが作られるまで待つ。
+until awslocal s3 ls "s3://${BUCKET}" > /dev/null 2>&1; do
+    sleep 2
+done
+
+cd /workspace
+rm -f lambda.zip
+zip -q lambda.zip bootstrap
+
+if awslocal lambda get-function --function-name "$FUNCTION_NAME" > /dev/null 2>&1; then
+    echo "[deploy-lambda] updating existing function"
+    awslocal lambda update-function-code \
+        --function-name "$FUNCTION_NAME" \
+        --zip-file fileb://lambda.zip > /dev/null
+else
+    echo "[deploy-lambda] creating function"
+    awslocal lambda create-function \
+        --function-name "$FUNCTION_NAME" \
+        --runtime provided.al2 \
+        --handler bootstrap \
+        --role "$ROLE_ARN" \
+        --zip-file fileb://lambda.zip \
+        --timeout 30 \
+        --memory-size 256 \
+        --environment "Variables={LAB_LAMBDA_BUCKET=${BUCKET}}" > /dev/null
+fi
+
+echo "[deploy-lambda] waiting for function to be Active"
+# LocalStack の Lambda は非同期に Active になるため provisioning 完了を待つ。
+for _ in $(seq 1 30); do
+    STATE=$(awslocal lambda get-function --function-name "$FUNCTION_NAME" --query 'Configuration.State' --output text 2>/dev/null || true)
+    if [ "$STATE" = "Active" ]; then
+        break
+    fi
+    sleep 1
+done
+
+FUNCTION_ARN=$(awslocal lambda get-function --function-name "$FUNCTION_NAME" --query 'Configuration.FunctionArn' --output text)
+echo "[deploy-lambda] function ARN: $FUNCTION_ARN"
+
+# S3 → Lambda 呼び出し権限。既にあれば無視。
+awslocal lambda add-permission \
+    --function-name "$FUNCTION_NAME" \
+    --statement-id s3-invoke \
+    --action lambda:InvokeFunction \
+    --principal s3.amazonaws.com \
+    --source-arn "arn:aws:s3:::${BUCKET}" > /dev/null 2>&1 || true
+
+echo "[deploy-lambda] configuring S3 event notification on ${BUCKET} (prefix=uploads/)"
+# prefix=uploads/ を絞ることで results/ への書き戻しが再発火しないようにしている。
+# (Lambda 側でも results/ プレフィックスの early return を入れているが二重防御)
+cat > /tmp/s3-notification.json <<EOF
+{
+  "LambdaFunctionConfigurations": [
+    {
+      "Id": "lab-lambda-on-uploads",
+      "LambdaFunctionArn": "${FUNCTION_ARN}",
+      "Events": ["s3:ObjectCreated:Put"],
+      "Filter": {
+        "Key": {
+          "FilterRules": [
+            { "Name": "prefix", "Value": "uploads/" }
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+
+awslocal s3api put-bucket-notification-configuration \
+    --bucket "$BUCKET" \
+    --notification-configuration file:///tmp/s3-notification.json
+
+# lab-lambda バケットにも CORS を付けておく (presigned PUT をブラウザから叩くため)。
+# init-localstack.sh では lab-uploads にしか入れてないので、ここで補完。
+cat > /tmp/lab-lambda-cors.json <<'EOF'
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["*"],
+      "AllowedMethods": ["PUT", "GET", "HEAD"],
+      "AllowedHeaders": ["*"],
+      "ExposeHeaders": ["ETag"],
+      "MaxAgeSeconds": 3000
+    }
+  ]
+}
+EOF
+awslocal s3api put-bucket-cors \
+    --bucket "$BUCKET" \
+    --cors-configuration file:///tmp/lab-lambda-cors.json
+
+echo "[deploy-lambda] done"

--- a/scripts/init-localstack.sh
+++ b/scripts/init-localstack.sh
@@ -9,6 +9,9 @@ REGION=ap-northeast-1
 
 echo "[init] creating S3 buckets"
 awslocal s3 mb s3://lab-uploads --region "$REGION"
+# lab-lambda バケットは #4 Lambda 用。uploads/ への PutObject を
+# トリガーに Lambda が起動し、results/ に処理結果 JSON を書き戻す。
+# 実際の CORS 設定やイベント通知は scripts/deploy-lambda.sh (lambda-deployer サービス) が行う。
 awslocal s3 mb s3://lab-lambda --region "$REGION"
 
 echo "[init] configuring S3 CORS on lab-uploads (required for browser PUT)"

--- a/src/handlers/lab_lambda_handler.go
+++ b/src/handlers/lab_lambda_handler.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/labstack/echo/v4"
+)
+
+// LabLambdaHandler は S3 → Lambda トリガー lab 用のハンドラ。
+// ブラウザは lab-lambda バケットに presigned PUT でアップロードし、
+// LocalStack の S3 イベント通知で発火した Go Lambda が
+// results/{key}.json を書き戻す。フロントは results/ を polling して結果を表示する。
+type LabLambdaHandler struct {
+	client        *s3.Client
+	presignClient *s3.PresignClient
+	bucket        string
+}
+
+// NewLabLambdaHandler は backend 内部 S3 クライアントとブラウザ向け presigned URL
+// 生成用クライアントを分離して初期化する (LabS3Handler と同じ理由)。
+func NewLabLambdaHandler() (*LabLambdaHandler, error) {
+	ctx := context.Background()
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(getenv("AWS_REGION", "ap-northeast-1")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	internalEndpoint := os.Getenv("AWS_ENDPOINT_URL")
+	internalClient := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if internalEndpoint != "" {
+			o.BaseEndpoint = aws.String(internalEndpoint)
+			o.UsePathStyle = true
+		}
+	})
+
+	publicEndpoint := getenv("AWS_PUBLIC_ENDPOINT_URL", "http://localhost:4566")
+	presignSource := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(publicEndpoint)
+		o.UsePathStyle = true
+	})
+
+	return &LabLambdaHandler{
+		client:        internalClient,
+		presignClient: s3.NewPresignClient(presignSource),
+		bucket:        getenv("LAB_LAMBDA_BUCKET", "lab-lambda"),
+	}, nil
+}
+
+type lambdaPresignPutReq struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+}
+
+type lambdaPresignPutRes struct {
+	URL string `json:"url"`
+	Key string `json:"key"`
+}
+
+// PresignPut は lab-lambda バケットの uploads/ prefix に向けた PUT 用 presigned URL を発行する。
+// ブラウザがこの URL に PUT すると S3 イベント通知 → Lambda が発火する。
+func (h *LabLambdaHandler) PresignPut(c echo.Context) error {
+	var req lambdaPresignPutReq
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if req.Filename == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "filename required")
+	}
+	key := fmt.Sprintf("uploads/%s-%s", time.Now().UTC().Format("20060102-150405"), req.Filename)
+
+	presigned, err := h.presignClient.PresignPutObject(c.Request().Context(), &s3.PutObjectInput{
+		Bucket:      aws.String(h.bucket),
+		Key:         aws.String(key),
+		ContentType: aws.String(req.ContentType),
+	}, s3.WithPresignExpires(15*time.Minute))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, lambdaPresignPutRes{URL: presigned.URL, Key: key})
+}
+
+type lambdaObject struct {
+	Key          string `json:"key"`
+	Size         int64  `json:"size"`
+	LastModified string `json:"lastModified"`
+}
+
+type lambdaResult struct {
+	Key          string          `json:"key"`
+	Size         int64           `json:"size"`
+	LastModified string          `json:"lastModified"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
+}
+
+// ListUploads は uploads/ 配下の元ファイル一覧を返す。
+func (h *LabLambdaHandler) ListUploads(c echo.Context) error {
+	items, err := h.list(c.Request().Context(), "uploads/")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, map[string]any{"uploads": items})
+}
+
+// ListResults は results/ 配下の JSON を一覧する。
+// 小さい JSON (< 64 KiB) は payload に中身をそのまま埋めて、フロントが 1 回の API で
+// 処理結果を表示できるようにする。
+func (h *LabLambdaHandler) ListResults(c echo.Context) error {
+	ctx := c.Request().Context()
+	items, err := h.list(ctx, "results/")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	results := make([]lambdaResult, 0, len(items))
+	for _, it := range items {
+		r := lambdaResult{Key: it.Key, Size: it.Size, LastModified: it.LastModified}
+		if it.Size > 0 && it.Size < 1<<16 {
+			out, err := h.client.GetObject(ctx, &s3.GetObjectInput{
+				Bucket: aws.String(h.bucket),
+				Key:    aws.String(it.Key),
+			})
+			if err == nil {
+				data, _ := io.ReadAll(out.Body)
+				out.Body.Close()
+				r.Payload = data
+			}
+		}
+		results = append(results, r)
+	}
+	return c.JSON(http.StatusOK, map[string]any{"results": results})
+}
+
+func (h *LabLambdaHandler) list(ctx context.Context, prefix string) ([]lambdaObject, error) {
+	out, err := h.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket: aws.String(h.bucket),
+		Prefix: aws.String(prefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+	items := make([]lambdaObject, 0, len(out.Contents))
+	for _, o := range out.Contents {
+		lm := ""
+		if o.LastModified != nil {
+			lm = o.LastModified.UTC().Format(time.RFC3339)
+		}
+		size := int64(0)
+		if o.Size != nil {
+			size = *o.Size
+		}
+		items = append(items, lambdaObject{
+			Key:          aws.ToString(o.Key),
+			Size:         size,
+			LastModified: lm,
+		})
+	}
+	return items, nil
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -25,6 +25,11 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 	if labSNSHandler != nil {
 		lab.POST("/sns/publish", labSNSHandler.PublishToTopic)
 		lab.GET("/sns/stats", labSNSHandler.FanoutStats)
+	}
+	if labLambdaHandler != nil {
+		lab.POST("/lambda/presign-put", labLambdaHandler.PresignPut)
+		lab.GET("/lambda/uploads", labLambdaHandler.ListUploads)
+		lab.GET("/lambda/results", labLambdaHandler.ListResults)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
## 実装概要

lab 第 4 弾。`lab-lambda` バケットの `uploads/` に PUT されたオブジェクトを Go Lambda が LocalStack 上で処理し、`results/{key}.json` に SHA-256 / サイズ / Content-Type を書き戻す S3 → Lambda のイベント駆動 lab。

- **Lambda**: `cmd/lambda/main.go` (aws-lambda-go)。provided.al2 runtime で `bootstrap` バイナリを実行
- **Deployer**: `cmd/lambda/Dockerfile` + `scripts/deploy-lambda.sh` 一回限りサービスが build → zip → awslocal で create-function → S3 event notification 設定
- **Backend API**: `/api/lab/lambda/presign-put`, `/uploads`, `/results` の 3 本

### 変更ファイル

- `cmd/lambda/main.go` — Lambda 本体。`events.S3Event` を受けて GetObject → hash → PutObject
- `cmd/lambda/Dockerfile` — 2 stage build (golang:1.24 → python:3.11-slim + awslocal)
- `scripts/deploy-lambda.sh` — LocalStack へのデプロイと S3 event 通知設定
- `src/handlers/lab_lambda_handler.go` — 新規。presigned PUT 発行 + uploads / results の一覧
- `src/routes/routes.go`, `main.go` — handler 接続
- `docker-compose.lab.yml` — `lambda-deployer` サービス、`LAB_LAMBDA_BUCKET` env 追加
- `scripts/init-localstack.sh` — `lab-lambda` バケット作成コメント補足
- `go.mod`, `go.sum` — `github.com/aws/aws-lambda-go` 追加

### エンドポイント

| method | path | 役割 |
|---|---|---|
| POST | `/api/lab/lambda/presign-put` | `lab-lambda/uploads/*` 向け presigned URL (15 分) |
| GET  | `/api/lab/lambda/uploads` | `uploads/` の一覧 |
| GET  | `/api/lab/lambda/results` | `results/` の一覧。< 64 KiB の JSON は payload に展開 |

## 設計判断の「なぜ」

### なぜ provided.al2 runtime か（go1.x ではなく）

AWS は 2023 年末に Go 1.x managed runtime を deprecated にし、**Amazon Linux 2 / 2023 の custom runtime (`provided.al2` / `provided.al2023`) + 静的リンクされた `bootstrap` バイナリ** が推奨になった。本番と一致させるため lab でも `provided.al2` を選択。

| runtime | 状況 |
|---|---|
| `go1.x` | deprecated (2023-12-31 以降 新規作成不可) |
| **`provided.al2`** | 現行推奨。`bootstrap` 命名が必須 |
| `provided.al2023` | より新しい。lambda 側の都合で差異あり。lab では `al2` でも `al2023` でも体感差ない |

### なぜ Lambda 結果を同じバケットの `results/` に書くか

選択肢:

| 方式 | 長所 | 短所 |
|---|---|---|
| **A. 同一バケット + prefix 分離 (本 PR)** | インフラが少ない、IAM が 1 つで済む | 無限ループの罠 (results/ への PutObject で自分自身を再発火させてしまう) |
| B. 結果専用の別バケット | 完全に責務分離、bucket policy で強固に分離 | バケットが増える、Terraform / IAM / 通知が倍になる |
| C. DynamoDB / RDS に書き込み | 検索・集計に向く | lab の学習目的には重い |

B2B SaaS の lab 学習用なので **A** を採用。無限ループは:
1. S3 イベント通知側で `prefix=uploads/` で filter (一次防御)
2. Lambda 本体でも `strings.HasPrefix(key, "results/")` で early return (二重防御)

の 2 段で防いでいる。**これは実務でも非常にハマる罠**で、S3 → Lambda 導入事故の 2 トップが「無限ループ」と「IAM 過不足」。

### なぜ lambda-deployer を別コンテナに切ったか

- LocalStack 本体のコンテナに Go ツールチェインを持ち込みたくない (init-localstack.sh は bash + awslocal のみに保ちたい)
- backend Dockerfile に Lambda バイナリビルドを混ぜると「app バイナリ」「worker バイナリ」「lambda バイナリ」の 3 つが同じ image に入って責務がぼやける
- docker-compose の `restart: "no"` で「起動時に 1 回だけ deploy して退出」の one-shot サービスとして明確化できる

### なぜ Lambda 内で `LOCALSTACK_HOSTNAME` を見ているか

LocalStack は Lambda コンテナに `LOCALSTACK_HOSTNAME` と `AWS_ENDPOINT_URL` のどちらか (バージョンにより挙動が違う) を注入する。どちらでも動くようにしてあり、**本番 AWS ではどちらの env も存在しないので `BaseEndpoint` override はかからず通常の AWS 公開エンドポイントに向く** という条件付きロジック。

### なぜ 64 KiB 未満の結果 JSON を API が payload に展開するか

polling UI で「各 result ごとに `GetObject` を 1 回打ってから中身を見せる」は n+1 リクエストが発生する。結果 JSON は 200 byte 前後なので、一覧 API 側で中身を埋めてフロントを素直にしている。64 KiB 上限はサーバー memory / レスポンスサイズの暴走防止の sanity check。

## ハマりポイント・注意事項

### 1. 無限ループ事故

`uploads/` と `results/` を同じバケットに置く設計では、S3 event filter を忘れると **Lambda が自分の書き出した JSON で再発火し、results/results/results/... が増殖する**。本 PR では filter + prefix guard の二重防御。本番 terraform では `aws_s3_bucket_notification` の `filter_prefix = "uploads/"` を必ず書く。

### 2. `bootstrap` という固定名

provided.al2 では zip のルートに `bootstrap` という実行可能バイナリを置かないと起動しない。Dockerfile の `go build -o /out/bootstrap` でこれを守っている。

### 3. LocalStack の Lambda `State`

`create-function` 直後は `State=Pending`。S3 イベント通知を設定する前に `Active` を待たないと、初回 PUT がロストする可能性がある。deploy-lambda.sh で 30 秒までポーリングする。

### 4. LocalStack の ARN region が `us-east-1`

LocalStack Community 版は env で region 指定しても Lambda ARN は `us-east-1` で返ることがある (3.x の仕様)。本番ではちゃんと指定した region で返る。

### 5. IAM role ARN は LocalStack では実在性を見ない

`arn:aws:iam::000000000000:role/lambda-role` という dummy ARN でも Lambda 作成が通る。本番では実在する execution role が必須で、最低 `AWSLambdaBasicExecutionRole` + `s3:GetObject` / `s3:PutObject` が必要。

## 本番 AWS との差分・設定箇所

| 項目 | ローカル (LocalStack) | 本番 AWS |
|---|---|---|
| Lambda 作成 | `awslocal lambda create-function` | Terraform `aws_lambda_function` + S3 にビルド成果物 zip |
| Execution role | dummy ARN で通る | `aws_iam_role` + `AWSLambdaBasicExecutionRole` + `s3:Get/Put` policy |
| S3 event 通知 | `awslocal s3api put-bucket-notification-configuration` | `aws_s3_bucket_notification` + `aws_lambda_permission` |
| zip のホスティング | inline ZipFile | S3 bucket に upload (> 50 MB なら必須) |
| Build | deploy-lambda.sh で毎回ビルド | CI で build → S3 → `source_code_hash` で差分検知 |
| Observability | `docker logs` | CloudWatch Logs + Lambda Insights |

### Terraform 最小セット

```hcl
resource "aws_s3_bucket" "lab_lambda" { bucket = "prod-lab-lambda" }

resource "aws_iam_role" "lambda" {
  name = "prod-lab-s3-processor"
  assume_role_policy = jsonencode({
    Statement = [{
      Effect = "Allow"
      Principal = { Service = "lambda.amazonaws.com" }
      Action = "sts:AssumeRole"
    }]
  })
}

resource "aws_iam_role_policy_attachment" "basic" {
  role       = aws_iam_role.lambda.name
  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
}

resource "aws_iam_role_policy" "s3" {
  role = aws_iam_role.lambda.id
  policy = jsonencode({
    Statement = [{
      Effect = "Allow"
      Action = ["s3:GetObject", "s3:PutObject"]
      Resource = "${aws_s3_bucket.lab_lambda.arn}/*"
    }]
  })
}

resource "aws_lambda_function" "processor" {
  function_name    = "prod-lab-s3-processor"
  role             = aws_iam_role.lambda.arn
  runtime          = "provided.al2"
  handler          = "bootstrap"
  filename         = "bootstrap.zip"
  source_code_hash = filebase64sha256("bootstrap.zip")
}

resource "aws_lambda_permission" "s3" {
  statement_id  = "AllowS3Invoke"
  action        = "lambda:InvokeFunction"
  function_name = aws_lambda_function.processor.arn
  principal     = "s3.amazonaws.com"
  source_arn    = aws_s3_bucket.lab_lambda.arn
}

resource "aws_s3_bucket_notification" "uploads" {
  bucket = aws_s3_bucket.lab_lambda.id

  lambda_function {
    lambda_function_arn = aws_lambda_function.processor.arn
    events              = ["s3:ObjectCreated:Put"]
    filter_prefix       = "uploads/"   # 無限ループ防止に必須
  }

  depends_on = [aws_lambda_permission.s3]
}
```

## 面接で話せるポイント

- **S3 → Lambda の典型ユースケース**: 画像サムネイル生成、PDF テキスト抽出、ウイルススキャン、ログ加工、S3 → S3 ETL
- **無限ループ事故の防ぎ方**: S3 event filter の prefix 分離、別バケット分離、Lambda 内 early return
- **コールドスタート対策**: provisioned concurrency、Lambda SnapStart (Go は対応外だが Java にはあり)、軽量バイナリ (Go は OK)
- **Go Lambda の利点**: コールドスタートが速い (10-100ms)、バイナリが小さい、型安全
- **Lambda vs ECS/EC2 の使い分け**: イベント駆動・散発的なら Lambda、常時稼働の API なら ECS。Lambda は 15 分上限・ステートレス前提
- **at-least-once の扱い**: Lambda は retry ポリシーあり (非同期呼び出しで 2 回)、冪等性が必要
- **同期 vs 非同期 invoke**: S3 event は非同期、API Gateway は同期。DLQ / retry ポリシーが異なる
- **バッチ処理**: S3 イベントは 1 record とは限らない。Records slice を必ず loop する (本 PR も対応)

## Test plan

- [x] `make rebuild` で localstack / backend / worker / lambda-deployer が起動
- [x] `docker logs fanc-api-lambda-deployer-1` で `[deploy-lambda] done` を確認
- [x] `awslocal lambda list-functions` で `lab-s3-processor` が見える
- [x] `awslocal s3 cp hello.txt s3://lab-lambda/uploads/` → 数秒後に `results/hello.txt.json` が出現
- [x] 結果 JSON に `sha256` / `size` / `contentType` / `processedAt` が含まれる
- [x] `curl /api/lab/lambda/results` で payload が展開されて返る
- [x] `go build ./...` が通る

### 関連 PR

- Frontend: `fanc-front feature/lab-lambda`

🤖 Generated with [Claude Code](https://claude.com/claude-code)