### PR TITLE
feat(lab): Redis Cache-Aside の API を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,17 @@ db/
   - `GET  /api/lab/sqs/stats` — primary / dlq の概算メッセージ数
   - `POST /api/lab/sns/publish` — lab-events topic に publish → lab-primary / lab-audit へ fanout
   - `GET  /api/lab/sns/stats` — primary / audit の概算メッセージ数
+  - `GET  /api/lab/cache/schools` — Redis Cache-Aside（HIT/MISS/elapsedMs を返却、TTL 60s、DB 側に 300ms 擬似遅延）
+  - `DELETE /api/lab/cache/schools` — キャッシュ key 削除
 
 lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。1 プロセス内で **2 goroutine が primary / audit を独立に long polling** する構造で、SNS → SQS fanout の両キュー同時消費を観察できる。"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動も観察可能。
 
   ナレッジ集:
   - ファイルアップロード方式 (A/B/C): `~/.claude/docs/interview/system-design/file-upload-patterns.md`
   - SQS 運用ノウハウ（VisibilityTimeout / DLQ / スケール）: `~/.claude/docs/interview/system-design/sqs-essentials.md`
+  - SNS → SQS fanout: `~/.claude/docs/interview/system-design/sns-fanout-essentials.md`
+  - S3 起点 Lambda: `~/.claude/docs/interview/system-design/s3-lambda-essentials.md`
+  - Redis Cache-Aside: `~/.claude/docs/interview/system-design/fanc-lab/5-cache-aside.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 // indirect
 	github.com/aws/smithy-go v1.25.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
@@ -44,9 +46,11 @@ require (
 	github.com/leodido/go-urn v1.2.3 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,9 +40,13 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.42.0 h1:ks8KBcZPh3PYISr5dAiXCM5/Thcu
 github.com/aws/aws-sdk-go-v2/service/sts v1.42.0/go.mod h1:pFw33T0WLvXU3rw1WBkpMlkgIn54eCB5FYLhjDc9Foo=
 github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
 github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
@@ -77,6 +81,8 @@ github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp9
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
 github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
 github.com/sendgrid/sendgrid-go v3.12.0+incompatible h1:/N2vx18Fg1KmQOh6zESc5FJB8pYwt5QFBDflYPh1KVg=
@@ -94,6 +100,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=

--- a/main.go
+++ b/main.go
@@ -72,8 +72,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab lambda handler init failed, /api/lab/lambda/* disabled: %s", err.Error())
 	}
+	labCacheHandler, err := handlers.NewLabCacheHandler(db)
+	if err != nil {
+		e.Logger.Warnf("lab cache handler init failed, /api/lab/cache/* disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler)
 
 	e.Start(":8080")
 }

--- a/src/handlers/lab_cache_handler.go
+++ b/src/handlers/lab_cache_handler.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"fanc-api/src/models"
+
+	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
+)
+
+// LabCacheHandler は Redis による Cache-Aside パターンを体験するための lab 用ハンドラ。
+// GET は HIT なら Redis、MISS なら MySQL から読み Redis に書き戻す。
+// DB 側には擬似遅延を入れてキャッシュ効果を視覚化する。
+type LabCacheHandler struct {
+	db    *gorm.DB
+	rdb   *redis.Client
+	key   string
+	ttl   time.Duration
+	delay time.Duration
+}
+
+const (
+	labCacheKey        = "lab:schools:v1"
+	labCacheTTL        = 60 * time.Second
+	labCacheDBFakeWait = 300 * time.Millisecond
+)
+
+// NewLabCacheHandler は Redis クライアントと DB を受け取って初期化する。
+// 既存 lab ハンドラ群にならい、接続不能でも init 自体は成功させる（実リクエスト時にエラー）。
+func NewLabCacheHandler(db *gorm.DB) (*LabCacheHandler, error) {
+	addr := getenv("REDIS_ADDR", "redis:6379")
+	rdb := redis.NewClient(&redis.Options{Addr: addr})
+	return &LabCacheHandler{
+		db:    db,
+		rdb:   rdb,
+		key:   labCacheKey,
+		ttl:   labCacheTTL,
+		delay: labCacheDBFakeWait,
+	}, nil
+}
+
+type labSchool struct {
+	ID         uint   `json:"id"`
+	Name       string `json:"name"`
+	MonthlyFee int    `json:"monthlyFee"`
+}
+
+type cacheGetRes struct {
+	Source    string      `json:"source"`
+	ElapsedMs int64       `json:"elapsedMs"`
+	Schools   []labSchool `json:"schools"`
+}
+
+// GetSchools は Cache-Aside で schools 一覧を返す。
+// HIT → Redis からそのまま、MISS → DB 取得後に Redis へ保存。
+func (h *LabCacheHandler) GetSchools(c echo.Context) error {
+	ctx := c.Request().Context()
+	start := time.Now()
+
+	if val, err := h.rdb.Get(ctx, h.key).Bytes(); err == nil {
+		var items []labSchool
+		if jerr := json.Unmarshal(val, &items); jerr == nil {
+			return c.JSON(http.StatusOK, cacheGetRes{
+				Source:    "cache",
+				ElapsedMs: time.Since(start).Milliseconds(),
+				Schools:   items,
+			})
+		}
+	} else if !errors.Is(err, redis.Nil) {
+		// Redis 障害でも DB にフォールバックする（キャッシュは可用性を下げない設計が基本）
+		c.Logger().Warnf("cache get failed, fallback to db: %s", err.Error())
+	}
+
+	items, err := h.loadSchoolsFromDB(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	if payload, jerr := json.Marshal(items); jerr == nil {
+		if serr := h.rdb.Set(ctx, h.key, payload, h.ttl).Err(); serr != nil {
+			c.Logger().Warnf("cache set failed: %s", serr.Error())
+		}
+	}
+
+	return c.JSON(http.StatusOK, cacheGetRes{
+		Source:    "db",
+		ElapsedMs: time.Since(start).Milliseconds(),
+		Schools:   items,
+	})
+}
+
+// DeleteCache はキャッシュ key を削除する。UI の「キャッシュ削除」ボタンから呼ばれる。
+func (h *LabCacheHandler) DeleteCache(c echo.Context) error {
+	if err := h.rdb.Del(c.Request().Context(), h.key).Err(); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, map[string]any{"deleted": h.key})
+}
+
+// loadSchoolsFromDB は schools を id/name/monthly_fee のみ読む。
+// DB 呼び出しに見立てた固定遅延を入れてキャッシュ効果を可視化する。
+func (h *LabCacheHandler) loadSchoolsFromDB(ctx context.Context) ([]labSchool, error) {
+	select {
+	case <-time.After(h.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	var rows []models.School
+	if err := h.db.WithContext(ctx).
+		Select("id", "name", "monthly_fee").
+		Order("id ASC").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("query schools: %w", err)
+	}
+	items := make([]labSchool, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, labSchool{
+			ID:         r.ID,
+			Name:       r.Name,
+			MonthlyFee: r.MonthlyFee,
+		})
+	}
+	return items, nil
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -30,6 +30,10 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 		lab.POST("/lambda/presign-put", labLambdaHandler.PresignPut)
 		lab.GET("/lambda/uploads", labLambdaHandler.ListUploads)
 		lab.GET("/lambda/results", labLambdaHandler.ListResults)
+	}
+	if labCacheHandler != nil {
+		lab.GET("/cache/schools", labCacheHandler.GetSchools)
+		lab.DELETE("/cache/schools", labCacheHandler.DeleteCache)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
## 実装概要

fanc-lab カリキュラム #5 Redis Cache-Aside の API 側。`GET /api/lab/cache/schools` を Cache-Aside パターンで実装し、DB 読みには 300ms の擬似遅延を挟んで HIT/MISS の差を UI 側で視認できるようにした。

| ファイル | 役割 |
|---|---|
| `src/handlers/lab_cache_handler.go` | Cache-Aside 本体。`go-redis/v9` で Redis クライアントを持ち、HIT/MISS 判定、DB フォールバック、TTL 管理 |
| `src/routes/routes.go` | `GET /api/lab/cache/schools` と `DELETE /api/lab/cache/schools` を lab group に配線 |
| `main.go` | `NewLabCacheHandler(db)` を初期化。既存 lab handler にならい接続不能でも init 自体は成功させる |
| `go.mod` / `go.sum` | `github.com/redis/go-redis/v9` を追加 |
| `CLAUDE.md` | lab API 一覧とナレッジ集リンクを更新 |

環境（Redis コンテナ / `REDIS_ADDR=redis:6379`）は既に `docker-compose.lab.yml` に入っている。

## 設計判断の「なぜ」

### なぜ Cache-Aside か（Write-Through / Write-Back との比較）

| パターン | 読み | 書き | 向くケース |
|---|---|---|---|
| **Cache-Aside**（採用） | アプリが Redis → DB の順 | アプリが DB のみ、キャッシュは invalidate or TTL 任せ | 実装素直、Redis 障害時 DB フォールバックが自然 |
| Write-Through | Redis のみ | Redis → DB 同期書き | 整合性重視、書き込みレイテンシ増 |
| Write-Back | Redis のみ | Redis 即応、DB 非同期反映 | 高スループット要求、Redis 落ちでロスト許容 |

B2B SaaS MVP の原則として **書き込みレイテンシを犠牲にしない・Redis 障害で機能継続できる** を満たす Cache-Aside 一択。

### Redis 障害時は DB フォールバック

`redis.Nil` 以外のエラー（接続断など）はログだけ出して DB 読み込みに進む。キャッシュは可用性を下げないための layer なので「Redis 死んだらシステム全体が落ちる」のは設計ミス。

```go
if val, err := h.rdb.Get(ctx, h.key).Bytes(); err == nil { ... }
else if !errors.Is(err, redis.Nil) {
    c.Logger().Warnf("cache get failed, fallback to db: %s", err.Error())
}
```

### Key 命名に `v1` を含める

`lab:schools:v1` のように **スキーマバージョン** を key に含めておくと、将来 schools の返却形を変えた時に `v2` に切り替えるだけで旧キャッシュを捨てられる。`FLUSHDB` や手動 `DEL` を避けたい本番運用での定石。

### TTL 60s の意図

lab は HIT→MISS 遷移を観察しやすいよう短め。本番は用途によって秒〜時間。TTL を入れ忘れる（`Set` 第 4 引数に 0）と「無期限」になり stale データが延々残るのでレビュー時の注意点。

### DB 側の 300ms 擬似遅延

`time.After(300 * time.Millisecond)` で擬似 DB 遅延を入れている。本物の MySQL は十分速いので、そのままだと MISS でも数 ms で返ってキャッシュ効果が UI で見えない。あくまで lab 可視化目的で、本番相当ではない。

## ハマりポイント

- **TTL 忘れ**: `rdb.Set(ctx, key, val, 0)` だと無期限キャッシュ。stale が残る
- **シリアライザは JSON 固定**: msgpack / gob は速いが redis-cli で中身覗けない。lab はデバッグ優先
- **Thundering Herd**: 同じ key を大量並列が一斉 MISS → DB 直撃。本番は singleflight / locked populate が必要。今回の lab は触れない
- **書き込み時の invalidate**: write API を作る際は `rdb.Del(ctx, key)` を必ず呼ぶこと。今回は read only なので問題ない

## 本番 AWS との差分・本番で設定すべき箇所

| 項目 | lab | 本番 |
|---|---|---|
| 実装 | `redis:7-alpine` 単体コンテナ | **ElastiCache for Redis**（Primary + Replica / Multi-AZ） |
| 永続化 | なし | AOF / RDB（必要なら） |
| 認証 | なし | AUTH token + TLS in-transit |
| エンドポイント | `redis:6379` | `<cluster>.<region>.cache.amazonaws.com:6379` |
| ネットワーク | compose network | VPC 内のみ、SG で backend ECS / Lambda からの 6379 inbound だけ許可 |

本番設定項目：
- **ElastiCache**: Primary + Replica 最低 2 AZ、自動フェイルオーバー
- **Parameter Group**: `maxmemory-policy=allkeys-lru`（メモリ溢れ時 LRU 退避）
- **CloudWatch メトリクス**: `CacheHits`/`CacheMisses`, `Evictions`, `CurrConnections`, `DatabaseMemoryUsagePercentage`

### ElastiCache vs MemoryDB の使い分け

- **ElastiCache for Redis**: キャッシュ用途（データロスが許容される）
- **MemoryDB for Redis**: primary store 用途。書き込みが multi-AZ WAL に fsync されデータロス許容しない。値段は高い

Cache-Aside なら ElastiCache で十分。

## 面接で話せるポイント

- **キャッシュの狙い**: レイテンシ削減 / DB 負荷逃し / 両方（主目的で戦略が変わる）
- **Cache-Aside を選ぶ理由**: MVP で最も素直、Redis 障害時フォールバックが自然
- **整合性の捨て方**: TTL 60s = 「書き換え後最大 60s は古い値」を許容する設計。許容できないなら write 時 invalidate
- **Thundering Herd 対策**: singleflight / negative cache / probabilistic early expiration
- **stale-while-revalidate**: TTL 切れ瞬間の一斉 MISS を避けるため「TTL 切れでも一旦返しつつ裏で再取得」
- **選定軸**: ElastiCache / MemoryDB / DynamoDB DAX の使い分け

詳細は `~/.claude/docs/interview/system-design/fanc-lab/5-cache-aside.md`。

## Test plan

- [ ] `make up-lab` で backend + redis が起動する
- [ ] ブラウザ `/lab/cache` で「取得」→ `MISS / ~300ms`、緑バッジ
- [ ] もう一度「取得」→ `HIT / 数 ms`、黄バッジ
- [ ] 「キャッシュ削除」→ 次の取得が `MISS` に戻る
- [ ] schools テーブルが空でも空配列で動作（空もキャッシュされる）
- [ ] 60 秒放置 → TTL 切れで次の取得が `MISS`
- [ ] `redis-cli -p 6379 KEYS "lab:*"` で key 存在確認、`TTL lab:schools:v1` で残 TTL を観察

関連 UI PR: kudotaka0421/fanc-front#feature/lab-cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)