### PR TITLE
docs: Redis Cache-Aside ナレッジの参照パスを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり�
   - SQS 運用ノウハウ（VisibilityTimeout / DLQ / スケール）: `~/.claude/docs/interview/system-design/sqs-essentials.md`
   - SNS → SQS fanout: `~/.claude/docs/interview/system-design/sns-fanout-essentials.md`
   - S3 起点 Lambda: `~/.claude/docs/interview/system-design/s3-lambda-essentials.md`
-  - Redis Cache-Aside: `~/.claude/docs/interview/system-design/fanc-lab/5-cache-aside.md`
+  - Redis Cache-Aside: `~/.claude/docs/interview/system-design/cache-aside-essentials.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 


### PR DESCRIPTION
## 概要

claude-config 側で Cache-Aside ナレッジを `system-design/` 直下 + `cache-aside-essentials.md` にリネーム移動したので、CLAUDE.md の参照パスも追従。

## 変更

`CLAUDE.md` のナレッジ集リンク：

- before: `~/.claude/docs/interview/system-design/fanc-lab/5-cache-aside.md`
- after:  `~/.claude/docs/interview/system-design/cache-aside-essentials.md`

## なぜ

PR #77 で追加した時に `fanc-lab/` サブディレクトリに置いてしまったが、既存 essentials 系（sqs / sns-fanout / s3-lambda）は全て `system-design/` 直下にあり不一致だった。claude-config 側 PR #45 で修正したので、こちらもパスを合わせる。

## 関連

- claude-config: https://github.com/kudotaka0421/claude-config/pull/45

## Test plan

- [ ] CLAUDE.md の Redis Cache-Aside リンクが新パスを指していること
- [ ] `grep -r "fanc-lab/5-cache-aside" .` が空であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)