### PR TITLE
feat(lab): Postgres RANGE パーティション + partition pruning 可視化 API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ db/
   - `GET  /api/lab/rls/tenants` — RLS デモ用テナント一覧（UI ドロップダウン用）
   - `GET  /api/lab/rls/samples` — `X-Tenant-Id` ヘッダ → `SET LOCAL app.current_org_id` で samples 一覧取得（RLS policy で自動絞り込み）
   - `POST /api/lab/rls/samples` — samples 追加。`WITH CHECK` により他テナント org_id の INSERT は弾かれる
+  - `GET  /api/lab/partition` — `?from=YYYY-MM-DD&to=YYYY-MM-DD` で events (月次 RANGE パーティション、1 万件 seed) を絞り込み、件数・EXPLAIN ANALYZE・scan された partition 名一覧を返す（partition pruning の可視化）
 
 lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。1 プロセス内で **2 goroutine が primary / audit を独立に long polling** する構造で、SNS → SQS fanout の両キュー同時消費を観察できる。"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動も観察可能。
 
@@ -87,6 +88,7 @@ lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり�
   - S3 起点 Lambda: `~/.claude/docs/interview/system-design/s3-lambda-essentials.md`
   - Redis Cache-Aside: `~/.claude/docs/interview/system-design/cache-aside-essentials.md`
   - Postgres RLS（tenant isolation）: `~/.claude/docs/interview/system-design/postgres-rls-essentials.md`
+  - Postgres パーティショニング（partition pruning）: `~/.claude/docs/interview/system-design/postgres-partition-essentials.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM --platform=linux/amd64 golang:1.24
+FROM --platform=linux/amd64 golang:1.25
 
 # ワーキングディレクトリを設定
 WORKDIR /app

--- a/main.go
+++ b/main.go
@@ -80,8 +80,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab rls handler init failed, /api/lab/rls/* disabled: %s", err.Error())
 	}
+	labPartitionHandler, err := handlers.NewLabPartitionHandler()
+	if err != nil {
+		e.Logger.Warnf("lab partition handler init failed, /api/lab/partition disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler)
 
 	e.Start(":8080")
 }

--- a/scripts/init-postgres.sql
+++ b/scripts/init-postgres.sql
@@ -65,3 +65,57 @@ INSERT INTO samples (org_id, body) VALUES
     ('22222222-2222-2222-2222-222222222222', 'Globex: 領収書 Z')
 ON CONFLICT DO NOTHING;
 COMMIT;
+
+-- ============================================================
+-- #7 Postgres パーティショニング
+-- 月次 RANGE パーティション。パーティションキーは event_at。
+-- 日付範囲クエリで「触らないパーティション」が EXPLAIN から消えること
+-- (partition pruning) を目視するのが狙い。
+-- ポイント: パーティションキーは PRIMARY KEY に含める必要がある
+-- (Postgres の UNIQUE 制約は全パーティション横断で enforce できないため)。
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS events (
+    id       uuid        NOT NULL DEFAULT gen_random_uuid(),
+    event_at timestamptz NOT NULL,
+    body     text        NOT NULL,
+    PRIMARY KEY (id, event_at)
+) PARTITION BY RANGE (event_at);
+
+-- 2025-11 〜 2026-04 の 6 ヶ月ぶんをあらかじめ作っておく。
+-- 本番では pg_partman などで自動作成するのが定石だが lab では固定で十分。
+CREATE TABLE IF NOT EXISTS events_2025_11 PARTITION OF events
+    FOR VALUES FROM ('2025-11-01') TO ('2025-12-01');
+CREATE TABLE IF NOT EXISTS events_2025_12 PARTITION OF events
+    FOR VALUES FROM ('2025-12-01') TO ('2026-01-01');
+CREATE TABLE IF NOT EXISTS events_2026_01 PARTITION OF events
+    FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+CREATE TABLE IF NOT EXISTS events_2026_02 PARTITION OF events
+    FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+CREATE TABLE IF NOT EXISTS events_2026_03 PARTITION OF events
+    FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
+CREATE TABLE IF NOT EXISTS events_2026_04 PARTITION OF events
+    FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
+-- 範囲外の INSERT を受け止めるための default パーティション。
+-- default があるとクエリ時に pruning できないケースもあるため、
+-- 運用では "default を使わず事前に partition を作る" のが推奨。
+-- 本 lab では範囲外データが入らないことの観察用に置くだけ。
+CREATE TABLE IF NOT EXISTS events_default PARTITION OF events DEFAULT;
+
+-- 親テーブルに CREATE INDEX すると全パーティションに cascade される (PG11+)。
+CREATE INDEX IF NOT EXISTS events_event_at_idx ON events (event_at);
+
+-- 1 万件の seed。2025-11-01 から 180 日ぶんの一様分布。
+-- 同じ初期化スクリプトが 2 回走ると 2 倍投入されてしまうので、既に入っていれば skip する。
+DO $$
+BEGIN
+    IF (SELECT count(*) FROM events) = 0 THEN
+        INSERT INTO events (event_at, body)
+        SELECT
+            '2025-11-01 00:00:00+00'::timestamptz + (random() * 180 * interval '1 day'),
+            'event #' || g
+        FROM generate_series(1, 10000) AS g;
+    END IF;
+END $$;
+
+ANALYZE events;

--- a/src/handlers/lab_partition_handler.go
+++ b/src/handlers/lab_partition_handler.go
@@ -1,0 +1,225 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/labstack/echo/v4"
+)
+
+// LabPartitionHandler は Postgres の RANGE パーティションと partition pruning を
+// ブラウザから観察するための lab ハンドラ。events テーブル (月次 RANGE) に対して
+// 日付範囲クエリを実行し、EXPLAIN ANALYZE と「実際に触られた partition 一覧」を返す。
+type LabPartitionHandler struct {
+	pool *pgxpool.Pool
+}
+
+// NewLabPartitionHandler は POSTGRES_DSN で Postgres pool を作る。
+// DSN 未設定 or 接続不能の場合は nil handler を返し、上位で /api/lab/partition を無効化する。
+func NewLabPartitionHandler() (*LabPartitionHandler, error) {
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		return nil, errors.New("POSTGRES_DSN is empty")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &LabPartitionHandler{pool: pool}, nil
+}
+
+type partitionInfo struct {
+	Name    string `json:"name"`
+	Scanned bool   `json:"scanned"`
+}
+
+type labPartitionResp struct {
+	From              string          `json:"from"`
+	To                string          `json:"to"`
+	Count             int64           `json:"count"`
+	ElapsedMs         int64           `json:"elapsedMs"`
+	Partitions        []partitionInfo `json:"partitions"`
+	ScannedPartitions []string        `json:"scannedPartitions"`
+	Explain           string          `json:"explain"`
+}
+
+// Query は ?from=...&to=... で events を絞り込み、件数 / EXPLAIN ANALYZE /
+// どの partition が scan されたかを返す。partition pruning の効果を可視化するのが狙い。
+//
+// API の契約: from/to は ISO8601 (YYYY-MM-DD or RFC3339) を想定。パースしたうえで
+// パラメータ化クエリに渡すので SQL インジェクションの経路はない。
+func (h *LabPartitionHandler) Query(c echo.Context) error {
+	from, to, err := parseFromTo(c)
+	if err != nil {
+		return err
+	}
+	ctx := c.Request().Context()
+
+	// 件数は素直に COUNT(*)。小さいテーブルなので充分。
+	start := time.Now()
+	var count int64
+	if err := h.pool.QueryRow(ctx,
+		`SELECT count(*) FROM events WHERE event_at >= $1 AND event_at < $2`,
+		from, to,
+	).Scan(&count); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	elapsed := time.Since(start).Milliseconds()
+
+	// EXPLAIN ANALYZE で実行計画を取得。ANALYZE を付けると実際に実行される点に注意
+	// (本番で重いクエリに ANALYZE を付けると同じコストがかかる)。
+	explainText, err := h.explain(ctx, from, to)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// 全 partition 名と、EXPLAIN に現れた partition 名の差分を取って
+	// UI 側で「prune されたか否か」をハイライトできるようにする。
+	allPartitions, err := h.listPartitions(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	scanned := extractScannedPartitions(explainText, allPartitions)
+
+	scannedSet := make(map[string]struct{}, len(scanned))
+	for _, name := range scanned {
+		scannedSet[name] = struct{}{}
+	}
+	partitions := make([]partitionInfo, 0, len(allPartitions))
+	for _, name := range allPartitions {
+		_, hit := scannedSet[name]
+		partitions = append(partitions, partitionInfo{Name: name, Scanned: hit})
+	}
+
+	return c.JSON(http.StatusOK, labPartitionResp{
+		From:              from.Format(time.RFC3339),
+		To:                to.Format(time.RFC3339),
+		Count:             count,
+		ElapsedMs:         elapsed,
+		Partitions:        partitions,
+		ScannedPartitions: scanned,
+		Explain:           explainText,
+	})
+}
+
+// parseFromTo は ?from=&to= を time.Time に。YYYY-MM-DD 形式を優先で受け付け、
+// RFC3339 へのフォールバックも用意しておく (UI 側の値に揺れが出ても落ちないように)。
+func parseFromTo(c echo.Context) (time.Time, time.Time, error) {
+	fromStr := c.QueryParam("from")
+	toStr := c.QueryParam("to")
+	if fromStr == "" || toStr == "" {
+		return time.Time{}, time.Time{}, echo.NewHTTPError(http.StatusBadRequest, "from and to query params are required (YYYY-MM-DD)")
+	}
+	from, err := parseDateParam(fromStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, echo.NewHTTPError(http.StatusBadRequest, "invalid from: "+err.Error())
+	}
+	to, err := parseDateParam(toStr)
+	if err != nil {
+		return time.Time{}, time.Time{}, echo.NewHTTPError(http.StatusBadRequest, "invalid to: "+err.Error())
+	}
+	if !to.After(from) {
+		return time.Time{}, time.Time{}, echo.NewHTTPError(http.StatusBadRequest, "to must be after from")
+	}
+	return from, to, nil
+}
+
+func parseDateParam(s string) (time.Time, error) {
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Parse(time.RFC3339, s)
+}
+
+// explain は EXPLAIN (ANALYZE, BUFFERS) の結果をテキストで取得する。
+// pgx は複数行返却されるので行ごとに Scan して結合する。
+func (h *LabPartitionHandler) explain(ctx context.Context, from, to time.Time) (string, error) {
+	rows, err := h.pool.Query(ctx,
+		`EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM events WHERE event_at >= $1 AND event_at < $2`,
+		from, to,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			return "", err
+		}
+		lines = append(lines, line)
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// listPartitions は events テーブルの child partition 名を返す。
+// pg_inherits を見れば親子関係が分かる。
+func (h *LabPartitionHandler) listPartitions(ctx context.Context) ([]string, error) {
+	rows, err := h.pool.Query(ctx, `
+		SELECT c.relname
+		FROM pg_inherits i
+		JOIN pg_class c ON c.oid = i.inhrelid
+		JOIN pg_class p ON p.oid = i.inhparent
+		WHERE p.relname = 'events'
+		ORDER BY c.relname
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]string, 0)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
+}
+
+// extractScannedPartitions は EXPLAIN 出力から「実際に scan された partition 名」を拾う。
+// "Seq Scan on events_2026_01" や "Index Scan using ... on events_2026_01" の
+// ような行に出てくる partition 名を集める。
+// 同じ partition が複数ノードに現れても dedup する。
+func extractScannedPartitions(explainText string, allPartitions []string) []string {
+	if len(allPartitions) == 0 {
+		return nil
+	}
+	known := make(map[string]struct{}, len(allPartitions))
+	for _, p := range allPartitions {
+		known[p] = struct{}{}
+	}
+
+	// 単語境界 + 既知の partition 名のみを拾う正規表現。
+	// EXPLAIN 出力中の他の箇所 (例: "never executed") に同名が出ないので
+	// これで十分。
+	re := regexp.MustCompile(`\bevents_[a-z0-9_]+\b`)
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, m := range re.FindAllString(explainText, -1) {
+		if _, ok := known[m]; !ok {
+			continue
+		}
+		if _, dup := seen[m]; dup {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+	}
+	return out
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -39,6 +39,9 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 		lab.GET("/rls/tenants", labRLSHandler.ListTenants)
 		lab.GET("/rls/samples", labRLSHandler.ListSamples)
 		lab.POST("/rls/samples", labRLSHandler.CreateSample)
+	}
+	if labPartitionHandler != nil {
+		lab.GET("/partition", labPartitionHandler.Query)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
## 実装概要

fanc-lab カリキュラム #7 (Postgres パーティショニング) の API 側。`events` テーブルを `event_at` をキーにした**月次 RANGE パーティション**にして 1 万件 seed し、`GET /api/lab/partition?from=&to=` で件数 / EXPLAIN ANALYZE / どの partition が scan されたかを返す。範囲を狭めるほど partition pruning で scan 対象が減る挙動をブラウザ側で視認できる。

### 追加・変更点

| ファイル | 変更 |
|---------|------|
| `scripts/init-postgres.sql` | `events` partitioned table (6 ヶ月 + default) と 1 万件 seed を追加 |
| `src/handlers/lab_partition_handler.go` | 新規。COUNT + EXPLAIN ANALYZE + scan された partition 名の抽出 |
| `src/routes/routes.go` | `GET /api/lab/partition` 追加 |
| `main.go` | handler init |
| `CLAUDE.md` | エンドポイント一覧とナレッジリンク追記 |
| `Dockerfile` | Go 1.24 → 1.25 (go.mod が 1.25.0 になっていたのに合わせる) |

### スキーマ

```sql
CREATE TABLE events (
    id       uuid        NOT NULL DEFAULT gen_random_uuid(),
    event_at timestamptz NOT NULL,
    body     text        NOT NULL,
    PRIMARY KEY (id, event_at)
) PARTITION BY RANGE (event_at);

CREATE TABLE events_2025_11 PARTITION OF events FOR VALUES FROM ('2025-11-01') TO ('2025-12-01');
-- ... 2025-12 〜 2026-04
CREATE TABLE events_default PARTITION OF events DEFAULT;

CREATE INDEX events_event_at_idx ON events (event_at); -- 親に貼れば全 child に cascade (PG11+)
```

## 設計判断の「なぜ」

### なぜパーティション？（単純 index BTREE との比較）

| 目的 | パーティションが効く | 単純 index で済む |
|---|---|---|
| 古いデータの大量削除 (TTL) | ◎ `DROP PARTITION` 1 発 = O(1) | × DELETE は WAL 圧迫・VACUUM 必要 |
| 大量データの範囲クエリ | ◎ pruning で scan 対象を絞れる | △ index 効くが冷たいページが多い |
| OLTP の点クエリ | × オーバーヘッド | ◎ 最短 |
| UNIQUE 制約 | △ パーティションキーを含める必要あり | ◎ 自由 |

**パーティションを導入する最大のメリットは削除が安い**こと。「時系列で溜まり続けて古い方はいずれ捨てたい」系のテーブル (access log / audit log / イベント ストリーム) に典型的にはまる。B2B SaaS で「顧客ごとの履歴を半年保持」みたいな要件が出た瞬間にこのパターンになる。

range クエリの高速化は副次効果。index でも効くが、パーティションを切るとそもそも他 partition のページを buffer pool に乗せないで済む = cold cache 時の TPS が段違いに良くなる。

### なぜ月次レンジ？（他の粒度との比較）

- **日次**: partition 数が爆発 (1 年で 365 個)。planning time が増え過ぎる
- **週次**: 粒度は良いが境界が曖昧 (ISO 週 or 日曜/月曜始まり)
- **月次**（採用）: 業務要件 (月次締め / 月次レポート) と自然に合致、partition 数もちょうど良い (1 年で 12 個)
- **年次**: 粒度が荒すぎて pruning が弱い

**「クエリ条件と一致する粒度」が原則**。月次締めで WHERE を書くなら月次にするのがベスト。

### パーティションキーは PRIMARY KEY に含めないといけない

```sql
PRIMARY KEY (id, event_at)  -- ← event_at を含めないとエラー
```

Postgres は **パーティション横断で UNIQUE を enforce できない**ので、UNIQUE 制約を貼りたいなら制約列にパーティションキーを含める必要がある。これは「UUID 単独で unique」を諦めることを意味するが、実運用では衝突確率 0 なので問題にならない。

もし `UNIQUE (email)` のような制約が必要になったら、パーティショニングとの相性が悪いので **別テーブル (user ディレクトリ) を作って JOIN する** のが定石。

### default partition のトレードオフ

default partition があると、クエリが「どの partition に該当するか不確定」になるケースで **pruning が効かなくなる**ことがある。運用では:

- default partition を置かず、**事前に必要な partition を pg_partman 等で自動作成**する
- 範囲外の INSERT が来たら明示エラーにする

のが推奨。本 lab では「範囲外データが入るとどう見えるか」を観察するためあえて置いている。

### EXPLAIN の partition 名抽出は regex ベース

EXPLAIN FORMAT JSON の plan tree を walk すれば "Relation Name" が正確に取れるが、Go で任意の木を歩くのは面倒。今回は:

1. `pg_inherits` で events の child partition 名一覧を取得
2. EXPLAIN TEXT 出力を regex `\bevents_[a-z0-9_]+\b` でなめる
3. known な partition 名とのみマッチさせて dedup

EXPLAIN 出力中に partition 名と衝突する文字列が出ないため、この素朴な実装で十分。本番実装なら FORMAT JSON の方が堅牢。

### EXPLAIN ANALYZE は実行コストが同じ

`ANALYZE` は実際にクエリを実行して actual time / actual rows を埋めるため、**重いクエリに ANALYZE を付けると本番と同じ負荷がかかる**。lab では問題ないが、本番で「遅いクエリを EXPLAIN ANALYZE で調査」すると倍遅くなる点は意識すべき。

## ハマりポイント

- **パーティションキー ≠ PRIMARY KEY**: `PRIMARY KEY (id)` のままだと `ERROR: unique constraint on partitioned table must include all partitioning columns`。`(id, event_at)` にする必要がある
- **default partition の pruning 阻害**: default があるとクエリ計画時に「default に落ちる可能性」を考慮して pruning を諦めるケースがある。運用では置かないのが推奨
- **親への INSERT は OK / DELETE も OK**: 親テーブルを相手に INSERT/SELECT/DELETE すればよい。どの partition に実データが入るかは Postgres が決める
- **CREATE INDEX は親に貼る**: 子 partition ごとに貼る必要はない (PG11+)。親に貼れば future partition にも自動で cascade される
- **pg_partman を使うのが本番運用のデフォルト**: 月次 partition を手で pre-create するのは現実的ではない。Amazon RDS / Aurora でも pg_partman は extension として有効化できる

## 本番 AWS との差分

| 項目 | lab | 本番 |
|---|---|---|
| DB | `postgres:16-alpine` 単体コンテナ | Aurora PostgreSQL / RDS |
| partition 管理 | 手書きで月次を pre-create | **pg_partman** で自動作成 / 自動 drop |
| 監視 | なし | CloudWatch + Performance Insights で partition 別 I/O を確認 |
| 古いデータの TTL | なし | pg_partman の retention 設定で自動 DROP PARTITION |
| 統計情報 | `ANALYZE events;` 手動 | autovacuum に任せる (partition ごとに走る) |

本番設定項目:
- pg_partman の `p_interval='monthly'` + `premake=6` (6 ヶ月先まで作り置き)
- retention で古い partition を自動 drop (例: 1 年 retention)
- autovacuum が partition 単位で走るので大きい partition でも vacuum 時間が短い

## 面接で話せるポイント

- **パーティションの主目的**: 「範囲クエリ高速化」ではなく **「古いデータの安い削除」** が本質。DROP PARTITION は O(1)、DELETE は O(N) + WAL + VACUUM
- **粒度の選び方**: クエリ条件 (WHERE 句) と一致させる。日次締めなら日次、月次締めなら月次
- **パーティションキーを PRIMARY KEY に含める必要がある理由**: Postgres は partition 横断で UNIQUE を enforce できない
- **pruning を阻害するパターン**: default partition、関数呼び出し (`DATE_TRUNC('month', event_at)`) → キーを直接 WHERE に
- **運用で pg_partman を使う理由**: 手で partition を作り続けるのは現実的ではない。retention 付きで古い partition を自動で drop できる
- **代替手段: TimescaleDB**: Postgres extension。hypertable で自動 partition + 時系列クエリに最適化。time-series 専用なら TimescaleDB も選択肢
- **sharding との違い**: partition は **単一 DB 内**で物理ファイルを分割、sharding は **複数 DB**にレコードを分散。スケール方向が違う

## Test plan

- [x] `make up-lab` で backend + postgres が起動する
- [x] `curl "http://localhost:8090/api/lab/partition?from=2026-02-01&to=2026-03-01"` → 1552 rows / events_2026_02 のみ scan
- [x] 3 ヶ月範囲 (2026-01〜2026-04) → 3 partition scan
- [x] 全範囲 (2025-11〜2026-05) → 6 partition scan、default は scan されない
- [ ] ブラウザ `/lab/partition` で日付範囲指定 + partition ハイライトを目視
- [ ] `docker exec fanc-api-postgres-1 psql -U lab -d lab -c "\d events"` でパーティション関係を確認

関連 UI PR: kudotaka0421/fanc-front#feature/lab-postgres-partition

🤖 Generated with [Claude Code](https://claude.com/claude-code)