### PR TITLE
feat(lab): #8 Postgres Bulk ingest（COPY vs INSERT ループ）の API を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり�
   - Redis Cache-Aside: `~/.claude/docs/interview/system-design/cache-aside-essentials.md`
   - Postgres RLS（tenant isolation）: `~/.claude/docs/interview/system-design/postgres-rls-essentials.md`
   - Postgres パーティショニング（partition pruning）: `~/.claude/docs/interview/system-design/postgres-partition-essentials.md`
-  - Postgres bulk ingest（COPY vs INSERT ループ）: `~/.claude/docs/interview/system-design/fanc-lab/08-postgres-bulk.md`
+  - Postgres bulk ingest（個別 / multi-row / COPY / staging の使い分け）: `~/.claude/docs/interview/system-design/postgres-bulk-essentials.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ db/
   - `GET  /api/lab/rls/samples` — `X-Tenant-Id` ヘッダ → `SET LOCAL app.current_org_id` で samples 一覧取得（RLS policy で自動絞り込み）
   - `POST /api/lab/rls/samples` — samples 追加。`WITH CHECK` により他テナント org_id の INSERT は弾かれる
   - `GET  /api/lab/partition` — `?from=YYYY-MM-DD&to=YYYY-MM-DD` で events (月次 RANGE パーティション、1 万件 seed) を絞り込み、件数・EXPLAIN ANALYZE・scan された partition 名一覧を返す（partition pruning の可視化）
+  - `POST /api/lab/bulk` — `file` (CSV: `name,email,score`) + `method` (`copy` / `insert`) を受け取り `bulk_samples` に投入。TRUNCATE 後に実行し、所要時間 / 行数 / rows per ms を返す（pgx.CopyFrom vs INSERT ループの比較）
+  - `GET  /api/lab/bulk/count` — `bulk_samples` の現在件数
 
 lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。1 プロセス内で **2 goroutine が primary / audit を独立に long polling** する構造で、SNS → SQS fanout の両キュー同時消費を観察できる。"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動も観察可能。
 
@@ -89,6 +91,7 @@ lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり�
   - Redis Cache-Aside: `~/.claude/docs/interview/system-design/cache-aside-essentials.md`
   - Postgres RLS（tenant isolation）: `~/.claude/docs/interview/system-design/postgres-rls-essentials.md`
   - Postgres パーティショニング（partition pruning）: `~/.claude/docs/interview/system-design/postgres-partition-essentials.md`
+  - Postgres bulk ingest（COPY vs INSERT ループ）: `~/.claude/docs/interview/system-design/fanc-lab/08-postgres-bulk.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 

--- a/main.go
+++ b/main.go
@@ -84,8 +84,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab partition handler init failed, /api/lab/partition disabled: %s", err.Error())
 	}
+	labBulkHandler, err := handlers.NewLabBulkHandler()
+	if err != nil {
+		e.Logger.Warnf("lab bulk handler init failed, /api/lab/bulk disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler, labBulkHandler)
 
 	e.Start(":8080")
 }

--- a/scripts/init-postgres.sql
+++ b/scripts/init-postgres.sql
@@ -119,3 +119,18 @@ BEGIN
 END $$;
 
 ANALYZE events;
+
+-- ============================================================
+-- #8 Postgres Bulk
+-- pgx.CopyFrom (COPY FROM STDIN) と 1 件ずつ INSERT のループを比較するための
+-- 投入先テーブル。CSV から読んだレコードを素直に入れるだけの狭いスキーマ。
+-- ベンチ時に TRUNCATE してから投入し、所要時間を UI で比較する。
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS bulk_samples (
+    id         bigserial   PRIMARY KEY,
+    name       text        NOT NULL,
+    email      text        NOT NULL,
+    score      int         NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/src/handlers/lab_bulk_handler.go
+++ b/src/handlers/lab_bulk_handler.go
@@ -1,0 +1,199 @@
+package handlers
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/labstack/echo/v4"
+)
+
+// LabBulkHandler は大量レコードを Postgres に投入する際の
+// pgx.CopyFrom (COPY FROM STDIN) と 1 件ずつの INSERT ループを比較する lab ハンドラ。
+// CSV を受け取り、method に応じて 2 方式を切り替え、所要時間を返す。
+type LabBulkHandler struct {
+	pool *pgxpool.Pool
+}
+
+// NewLabBulkHandler は POSTGRES_DSN から pgxpool を作る。
+// DSN 未設定 or 接続不能なら nil を返し、上位で /api/lab/bulk を無効化する。
+func NewLabBulkHandler() (*LabBulkHandler, error) {
+	dsn := os.Getenv("POSTGRES_DSN")
+	if dsn == "" {
+		return nil, errors.New("POSTGRES_DSN is empty")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &LabBulkHandler{pool: pool}, nil
+}
+
+type bulkRow struct {
+	name  string
+	email string
+	score int
+}
+
+type labBulkResp struct {
+	Method    string `json:"method"`
+	Rows      int    `json:"rows"`
+	ElapsedMs int64  `json:"elapsedMs"`
+	RowsPerMs string `json:"rowsPerMs"`
+}
+
+type labBulkCountResp struct {
+	Count int64 `json:"count"`
+}
+
+// Count は bulk_samples の現在の件数を返す。UI で「投入後の残存」を確認するための補助。
+func (h *LabBulkHandler) Count(c echo.Context) error {
+	ctx := c.Request().Context()
+	var count int64
+	if err := h.pool.QueryRow(ctx, `SELECT count(*) FROM bulk_samples`).Scan(&count); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return c.JSON(http.StatusOK, labBulkCountResp{Count: count})
+}
+
+// Import は CSV を受け取り、method=copy | insert で bulk_samples に投入する。
+// 事前に TRUNCATE し、計測区間を「投入方式そのもの」だけに絞ることで比較を意味ある形にする。
+//
+// CSV の期待フォーマット (ヘッダ必須):
+//
+//	name,email,score
+//	alice,alice@example.com,42
+//	...
+func (h *LabBulkHandler) Import(c echo.Context) error {
+	method := c.FormValue("method")
+	if method != "copy" && method != "insert" {
+		return echo.NewHTTPError(http.StatusBadRequest, "method must be 'copy' or 'insert'")
+	}
+
+	fh, err := c.FormFile("file")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "file is required")
+	}
+	f, err := fh.Open()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	defer f.Close()
+
+	rows, err := parseBulkCSV(f)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if len(rows) == 0 {
+		return echo.NewHTTPError(http.StatusBadRequest, "CSV has no data rows")
+	}
+
+	ctx := c.Request().Context()
+
+	// 毎リクエスト TRUNCATE。直前の投入件数が混ざると所要時間の比較が狂う。
+	// 本番ではこんなことはしないが、lab のベンチ目的なら単純化を優先する。
+	if _, err := h.pool.Exec(ctx, `TRUNCATE TABLE bulk_samples RESTART IDENTITY`); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "truncate: "+err.Error())
+	}
+
+	start := time.Now()
+	switch method {
+	case "copy":
+		err = h.importCopy(ctx, rows)
+	case "insert":
+		err = h.importInsertLoop(ctx, rows)
+	}
+	elapsed := time.Since(start)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	elapsedMs := elapsed.Milliseconds()
+	rowsPerMs := "-"
+	if elapsedMs > 0 {
+		rowsPerMs = strconv.FormatFloat(float64(len(rows))/float64(elapsedMs), 'f', 2, 64)
+	}
+	return c.JSON(http.StatusOK, labBulkResp{
+		Method:    method,
+		Rows:      len(rows),
+		ElapsedMs: elapsedMs,
+		RowsPerMs: rowsPerMs,
+	})
+}
+
+// importCopy は pgx.CopyFrom で一括投入する。COPY プロトコルはクライアントから
+// バイナリに近い形でストリームするので、1 件ずつの往復が発生せず大量投入に圧倒的に強い。
+func (h *LabBulkHandler) importCopy(ctx context.Context, rows []bulkRow) error {
+	src := pgx.CopyFromSlice(len(rows), func(i int) ([]any, error) {
+		r := rows[i]
+		return []any{r.name, r.email, r.score}, nil
+	})
+	_, err := h.pool.CopyFrom(
+		ctx,
+		pgx.Identifier{"bulk_samples"},
+		[]string{"name", "email", "score"},
+		src,
+	)
+	return err
+}
+
+// importInsertLoop は 1 件ずつ INSERT を送る愚直な方式。
+// 1 トランザクションに包むことで COMMIT 回数は 1 回に抑えているが、ネットワーク往復は行数ぶん発生する。
+// あえて prepared statement や batch も使わず、COPY との差を際立たせる。
+func (h *LabBulkHandler) importInsertLoop(ctx context.Context, rows []bulkRow) error {
+	tx, err := h.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	for _, r := range rows {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO bulk_samples (name, email, score) VALUES ($1, $2, $3)`,
+			r.name, r.email, r.score,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// parseBulkCSV はヘッダ付き CSV を bulkRow の slice に。列順は name,email,score で固定。
+// スキーマが揺れると COPY 側の列順とズレてハマるので、寛容にせず固定で扱う。
+func parseBulkCSV(r io.Reader) ([]bulkRow, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = 3
+
+	header, err := reader.Read()
+	if err != nil {
+		return nil, errors.New("failed to read header: " + err.Error())
+	}
+	if len(header) != 3 || header[0] != "name" || header[1] != "email" || header[2] != "score" {
+		return nil, errors.New("CSV header must be: name,email,score")
+	}
+
+	out := make([]bulkRow, 0, 1024)
+	for i := 2; ; i++ {
+		rec, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, errors.New("row " + strconv.Itoa(i) + ": " + err.Error())
+		}
+		score, convErr := strconv.Atoi(rec[2])
+		if convErr != nil {
+			return nil, errors.New("row " + strconv.Itoa(i) + ": score must be int")
+		}
+		out = append(out, bulkRow{name: rec[0], email: rec[1], score: score})
+	}
+	return out, nil
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler, labBulkHandler *handlers.LabBulkHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -42,6 +42,10 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 	}
 	if labPartitionHandler != nil {
 		lab.GET("/partition", labPartitionHandler.Query)
+	}
+	if labBulkHandler != nil {
+		lab.POST("/bulk", labBulkHandler.Import)
+		lab.GET("/bulk/count", labBulkHandler.Count)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
fanc-lab カリキュラム #8 のバックエンド実装。CSV を受け取って `bulk_samples` に投入する 2 方式（`pgx.CopyFrom` と 1 件ずつの `INSERT` ループ）をブラウザからトグルで切り替えて所要時間を比較できるようにした。

## 実装概要

| ファイル | 変更 |
|---|---|
| `src/handlers/lab_bulk_handler.go` | 新規。`POST /api/lab/bulk`（multipart: `file`=CSV, `method`=copy/insert）と `GET /api/lab/bulk/count` |
| `scripts/init-postgres.sql` | `bulk_samples` テーブル DDL 追加（`name text, email text, score int, created_at timestamptz`） |
| `src/routes/routes.go` / `main.go` | ハンドラ登録。`POSTGRES_DSN` 未設定なら warn ログのみで無効化（既存 lab と同じ構造） |
| `CLAUDE.md` | lab API 一覧・ナレッジ参照に #8 を追記 |

### API の形

```
POST /api/lab/bulk    (multipart/form-data: file=<csv>, method=copy|insert)
 → { method, rows, elapsedMs, rowsPerMs }
GET  /api/lab/bulk/count
 → { count }
```

CSV は `name,email,score` の 3 列固定（ヘッダ必須）。`csv.Reader.FieldsPerRecord=3` で列数ズレを即エラー。

### 計測の公平性

- 毎リクエスト実行前に `TRUNCATE ... RESTART IDENTITY` で bulk_samples を空に → 「0 行からの全件投入」で両方式を揃える。
- 計測区間は `time.Since()` で「投入方式の処理そのもの」だけに絞る（CSV パース / TRUNCATE は含めない）。
- INSERT ループは 1 トランザクションに包んで COMMIT を 1 回だけに（不公平にならない範囲で自然に書く）。prepared statement / batch はあえて使わず、素朴な `tx.Exec` ループのまま。

## 設計判断の「なぜ」

### なぜ COPY 側を `pgx.CopyFrom` で書いたか

Postgres 向けの bulk ingest のデファクト。`pgx.Identifier{...}` で識別子 quote、`pgx.CopyFromSlice` で行生成関数を渡す形が ORM-less な素の pgx で最小コード。列順は第 3 引数の slice と行生成関数の `[]any` の順序に厳密に依存する（ここでハマる可能性があるので固定）。

### なぜ `TRUNCATE` を毎回叩いているか

「差分投入の時間」ではなく「0→N の時間」を見たい。アプリ視点では論外だが、lab なら明示的にリセットする方が差分が見やすい。PR としては `API 側で TRUNCATE を叩く` のは明らかに副作用なので、将来 lab 以外に `bulk_samples` を流用するなら切り出しが必要。

### なぜ INSERT ループに prepared 等を入れなかったか

「真の最適化済み INSERT」と比べると COPY の差が縮むが、目的は「素朴に書くと何倍違うか」の体感。prepared / batch / multi-row INSERT は面接で口頭で差分を説明できるので、コードとしては最もナイーブな形を残した（ナレッジメモ側で中間策について言及）。

### 既存 Postgres volume への DDL

init スクリプトは初回起動時しか走らないので、develop 取り込み後は手元で `docker compose ... exec postgres psql -U lab -d lab -c "CREATE TABLE IF NOT EXISTS bulk_samples ..."` を一発打つ必要がある（`IF NOT EXISTS` にしてあるのでボリューム削除不要）。

## 本番 AWS / PostgreSQL との差分

- **ON CONFLICT**: COPY は `ON CONFLICT` 句を持たない。本番で upsert したいなら「一時テーブルに COPY → `INSERT ... SELECT ... ON CONFLICT`」の 2 段流しが定石。
- **トランザクション境界**: 数百万行 COPY を 1 トランザクションに包むと vacuum が進まない・long lock で後続を詰まらせる。本番ではチャンク分割する。
- **エラー許容**: COPY 中に 1 行型違反が出ると全体 rollback。本番では staging テーブル経由で「入る行だけ入れて、不正行は別テーブルへ」のパターン。
- **S3 → DB**: RDS PostgreSQL なら `aws_s3.table_import_from_s3` 拡張で S3 から直接 COPY できる（Aurora は同等機能あり）。本 lab は multipart upload 経由。
- **インデックス**: 大量投入前に drop、投入後に再構築すると秒単位で縮む。本 lab の `bulk_samples` は PK のみなので気にしていない。

## ハマりポイント

- `pgx.CopyFromSlice` の行生成関数が返す `[]any` の列順は `CopyFrom` 第 3 引数の列名順に厳密一致（ズレても型さえ合えば黙って別カラムに入ってしまう）。
- 既存の Postgres ボリュームが残っている環境では init-postgres.sql が走らないので、手動で DDL を流す必要あり（`bulk_samples` に `IF NOT EXISTS` を付けて冪等にしてある）。
- 手元では Docker のディスク逼迫で Postgres が recovery loop に入ったため E2E の実測ができていない（`PANIC: could not write to file: No space left on device`）。ビルドと型チェックは通過。Docker cleanup 後に再計測予定。

## 面接で話せるポイント

- 「バルク投入何使う？」→ Postgres なら `COPY FROM STDIN`、MySQL なら `LOAD DATA INFILE` or multi-row INSERT。一般化は「per-row の parse/plan/exec を避けるストリーミング」。
- 「なぜ速い？」→ per-row の parse/plan コスト消滅、往復削減、WAL のまとめ書き。
- 「COPY 使えない場面は？」→ upsert したい、1 行ずつエラー許容したい。中間策として multi-row INSERT + UNNEST、prepared batch、staging table。
- 「どれくらい差つく？」→ 10k 行で 1 桁以上（lab で計測予定）。

ナレッジ: `~/.claude/docs/interview/system-design/fanc-lab/08-postgres-bulk.md` に本番観点の補足を集約した。

## Test plan

- [x] `go build ./...` パス
- [x] `bulk_samples` DDL を手元 Postgres に適用（確認済み）
- [ ] （Docker disk 復旧後）`/lab/bulk` で 10k 行投入し、COPY と INSERT の体感差を記録
- [ ] 空 CSV / ヘッダ不一致 / score 非数値でバリデーションエラーが返ることを確認

Closes なし（カリキュラム進捗表は `.claude/docs/interview/system-design/fanc-lab/curriculum.md` を参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)