### PR TITLE
feat(lab): #9 Circuit Breaker（gobreaker で Closed/Open/Half-Open を可視化）の API を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,10 @@ db/
   - `GET  /api/lab/partition` — `?from=YYYY-MM-DD&to=YYYY-MM-DD` で events (月次 RANGE パーティション、1 万件 seed) を絞り込み、件数・EXPLAIN ANALYZE・scan された partition 名一覧を返す（partition pruning の可視化）
   - `POST /api/lab/bulk` — `file` (CSV: `name,email,score`) + `method` (`copy` / `insert`) を受け取り `bulk_samples` に投入。TRUNCATE 後に実行し、所要時間 / 行数 / rows per ms を返す（pgx.CopyFrom vs INSERT ループの比較）
   - `GET  /api/lab/bulk/count` — `bulk_samples` の現在件数
+  - `GET  /api/lab/breaker/call` — `sony/gobreaker` を通して同プロセス内 mock upstream を HTTP 呼び出し。`ok`, `source` (`upstream`/`breaker`), `state`, `counts` を返す
+  - `GET  /api/lab/breaker/state` — 現在の state / counts / failMode / 状態遷移履歴
+  - `POST /api/lab/breaker/toggle-fail` — mock upstream の失敗モードを反転（ON の間は mock が 500 を返す）
+  - `GET  /api/lab/breaker/mock` — breaker の保護対象となる mock upstream（fail mode では 500、通常は 200）
 
 lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。1 プロセス内で **2 goroutine が primary / audit を独立に long polling** する構造で、SNS → SQS fanout の両キュー同時消費を観察できる。"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動も観察可能。
 
@@ -92,6 +96,7 @@ lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり�
   - Postgres RLS（tenant isolation）: `~/.claude/docs/interview/system-design/postgres-rls-essentials.md`
   - Postgres パーティショニング（partition pruning）: `~/.claude/docs/interview/system-design/postgres-partition-essentials.md`
   - Postgres bulk ingest（個別 / multi-row / COPY / staging の使い分け）: `~/.claude/docs/interview/system-design/postgres-bulk-essentials.md`
+  - Circuit Breaker（Closed/Open/Half-Open と閾値設計）: `~/.claude/docs/interview/system-design/circuit-breaker-essentials.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekuei
 github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
 github.com/sendgrid/sendgrid-go v3.12.0+incompatible h1:/N2vx18Fg1KmQOh6zESc5FJB8pYwt5QFBDflYPh1KVg=
 github.com/sendgrid/sendgrid-go v3.12.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/main.go
+++ b/main.go
@@ -88,8 +88,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab bulk handler init failed, /api/lab/bulk disabled: %s", err.Error())
 	}
+	labBreakerHandler, err := handlers.NewLabBreakerHandler()
+	if err != nil {
+		e.Logger.Warnf("lab breaker handler init failed, /api/lab/breaker/* disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler, labBulkHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler, labBulkHandler, labBreakerHandler)
 
 	e.Start(":8080")
 }

--- a/src/handlers/lab_breaker_handler.go
+++ b/src/handlers/lab_breaker_handler.go
@@ -1,0 +1,212 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sony/gobreaker/v2"
+)
+
+// LabBreakerHandler は sony/gobreaker で Circuit Breaker の 3 状態
+// (Closed / Open / Half-Open) を体感するための lab ハンドラ。
+// 同プロセス内にある mock エンドポイントを HTTP 越しに叩き、失敗モードを
+// トグルで切り替えて閾値超え → Open → タイムアウト経過 → Half-Open → Closed
+// の遷移を UI から観察する。
+type LabBreakerHandler struct {
+	cb          *gobreaker.CircuitBreaker[string]
+	httpClient  *http.Client
+	mockURL     string
+	failMode    atomic.Bool
+	mockLatency time.Duration
+
+	mu          sync.Mutex
+	transitions []stateTransition
+}
+
+type stateTransition struct {
+	At   time.Time             `json:"at"`
+	From gobreaker.State       `json:"from"`
+	To   gobreaker.State       `json:"to"`
+}
+
+// NewLabBreakerHandler は gobreaker を 3 failures / 5s Open / Half-Open 1 req の設定で初期化する。
+// 本番相当の厳しい値ではなく、UI 連打で遷移を全部観察できる「軽い値」に寄せている。
+func NewLabBreakerHandler() (*LabBreakerHandler, error) {
+	mockURL := getenv("LAB_BREAKER_MOCK_URL", "http://localhost:8080/api/lab/breaker/mock")
+	h := &LabBreakerHandler{
+		httpClient:  &http.Client{Timeout: 3 * time.Second},
+		mockURL:     mockURL,
+		mockLatency: parseDurationEnv("LAB_BREAKER_MOCK_LATENCY", 50*time.Millisecond),
+	}
+
+	settings := gobreaker.Settings{
+		Name:        "lab-upstream",
+		MaxRequests: 1,
+		Interval:    0, // 常時カウント（Closed 中に定期リセットしない）
+		Timeout:     5 * time.Second,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			h.transitions = append(h.transitions, stateTransition{
+				At: time.Now(), From: from, To: to,
+			})
+			if len(h.transitions) > 50 {
+				h.transitions = h.transitions[len(h.transitions)-50:]
+			}
+		},
+	}
+	h.cb = gobreaker.NewCircuitBreaker[string](settings)
+	return h, nil
+}
+
+type breakerCallResp struct {
+	Ok         bool                `json:"ok"`
+	Source     string              `json:"source"`
+	HTTPStatus int                 `json:"httpStatus,omitempty"`
+	Body       string              `json:"body,omitempty"`
+	Error      string              `json:"error,omitempty"`
+	State      string              `json:"state"`
+	Counts     gobreaker.Counts    `json:"counts"`
+	ElapsedMs  int64               `json:"elapsedMs"`
+}
+
+type breakerStateResp struct {
+	State       string            `json:"state"`
+	Counts      gobreaker.Counts  `json:"counts"`
+	FailMode    bool              `json:"failMode"`
+	Transitions []transitionView  `json:"transitions"`
+}
+
+type transitionView struct {
+	At   string `json:"at"`
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type breakerToggleResp struct {
+	FailMode bool `json:"failMode"`
+}
+
+// Call は gobreaker.Execute で mock エンドポイントを HTTP 越しに叩く。
+// Open 中は実際のリクエストが発生せず即 `ErrOpenState` が返る。
+// レスポンスに現在の state / counts を常に載せて UI の状態表示を更新する。
+func (h *LabBreakerHandler) Call(c echo.Context) error {
+	ctx := c.Request().Context()
+	start := time.Now()
+	body, err := h.cb.Execute(func() (string, error) {
+		return h.callMock(ctx)
+	})
+	elapsed := time.Since(start).Milliseconds()
+	state := h.cb.State().String()
+	counts := h.cb.Counts()
+
+	if err != nil {
+		source := "upstream"
+		if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+			// ErrOpenState: Open 中の短絡。ErrTooManyRequests: Half-Open 中に probe が既に走っている。
+			// どちらも「breaker が手前で止めた」ので、upstream に到達すらしていない。
+			source = "breaker"
+		}
+		return c.JSON(http.StatusOK, breakerCallResp{
+			Ok:        false,
+			Source:    source,
+			Error:     err.Error(),
+			State:     state,
+			Counts:    counts,
+			ElapsedMs: elapsed,
+		})
+	}
+	return c.JSON(http.StatusOK, breakerCallResp{
+		Ok:         true,
+		Source:     "upstream",
+		HTTPStatus: http.StatusOK,
+		Body:       body,
+		State:      state,
+		Counts:     counts,
+		ElapsedMs:  elapsed,
+	})
+}
+
+// State は UI のポーリング / 初期表示用に、現在の state と直近の遷移履歴を返す。
+func (h *LabBreakerHandler) State(c echo.Context) error {
+	h.mu.Lock()
+	trs := make([]transitionView, 0, len(h.transitions))
+	for _, t := range h.transitions {
+		trs = append(trs, transitionView{
+			At:   t.At.Format(time.RFC3339Nano),
+			From: t.From.String(),
+			To:   t.To.String(),
+		})
+	}
+	h.mu.Unlock()
+	return c.JSON(http.StatusOK, breakerStateResp{
+		State:       h.cb.State().String(),
+		Counts:      h.cb.Counts(),
+		FailMode:    h.failMode.Load(),
+		Transitions: trs,
+	})
+}
+
+// ToggleFail は mock 側の失敗モードを反転する。ON の間は mock が 500 を返すので
+// breaker 経由の呼び出しが失敗としてカウントされる。
+func (h *LabBreakerHandler) ToggleFail(c echo.Context) error {
+	next := !h.failMode.Load()
+	h.failMode.Store(next)
+	return c.JSON(http.StatusOK, breakerToggleResp{FailMode: next})
+}
+
+// Mock は breaker の保護対象となる upstream の代役。
+// failMode=true の間は 500 を返す。実際の外部 API を叩きに行くと lab の再現性が落ちるため、
+// 同プロセス内に置いて HTTP 越しに叩く形にした。
+func (h *LabBreakerHandler) Mock(c echo.Context) error {
+	time.Sleep(h.mockLatency)
+	if h.failMode.Load() {
+		return echo.NewHTTPError(http.StatusInternalServerError, "mock upstream in fail mode")
+	}
+	return c.JSON(http.StatusOK, map[string]any{"ok": true, "at": time.Now().Format(time.RFC3339)})
+}
+
+func (h *LabBreakerHandler) callMock(ctx context.Context) (string, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, h.mockURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 500 {
+		return "", fmt.Errorf("upstream %d: %s", resp.StatusCode, string(body))
+	}
+	return string(body), nil
+}
+
+func parseDurationEnv(key string, fallback time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	if ms, err := strconv.Atoi(v); err == nil {
+		return time.Duration(ms) * time.Millisecond
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return d
+	}
+	return fallback
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler, labBulkHandler *handlers.LabBulkHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler, labBulkHandler *handlers.LabBulkHandler, labBreakerHandler *handlers.LabBreakerHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -46,6 +46,12 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 	if labBulkHandler != nil {
 		lab.POST("/bulk", labBulkHandler.Import)
 		lab.GET("/bulk/count", labBulkHandler.Count)
+	}
+	if labBreakerHandler != nil {
+		lab.GET("/breaker/call", labBreakerHandler.Call)
+		lab.GET("/breaker/state", labBreakerHandler.State)
+		lab.POST("/breaker/toggle-fail", labBreakerHandler.ToggleFail)
+		lab.GET("/breaker/mock", labBreakerHandler.Mock)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
fanc-lab カリキュラム #9 のバックエンド実装。`sony/gobreaker/v2` で同プロセス内の mock upstream を保護し、失敗モードをトグルで切り替えて Closed → Open → Half-Open → Closed の状態遷移を UI から観察できるようにした。

## 実装概要

| ファイル | 変更 |
|---|---|
| `src/handlers/lab_breaker_handler.go` | 新規。`gobreaker.CircuitBreaker[string]` + 同プロセス内 mock + failMode トグル |
| `src/routes/routes.go` / `main.go` | ハンドラ登録。他 lab と同じく init 失敗時は warn ログだけで無効化 |
| `CLAUDE.md` | lab API 一覧に #9 を追記、ナレッジ参照に circuit-breaker-essentials を追記 |
| `go.mod` / `go.sum` | `github.com/sony/gobreaker/v2` 追加 |

### API の形

```
GET  /api/lab/breaker/call
 → { ok, source: "upstream"|"breaker", state, counts, elapsedMs, body?, error? }
GET  /api/lab/breaker/state
 → { state, counts, failMode, transitions: [{at, from, to}, ...] }
POST /api/lab/breaker/toggle-fail
 → { failMode }
GET  /api/lab/breaker/mock              # breaker の保護対象（failMode で 500 / 200）
```

## 設計判断の「なぜ」

### なぜ mock upstream を「同プロセス内の HTTP エンドポイント」にしたか

curriculum は「外部 mock API 呼び出し」と書いているが、実際の外部サービスを叩きに行くと lab の再現性が落ちる（ネットワーク揺らぎで breaker が意図せず trip する）。一方で「関数呼び出しで失敗を返すだけ」だと、タイムアウト挙動や HTTP status 変換など実運用に近い学びが落ちる。折衷として「同プロセス内の Echo ルートを `http.Client` で叩く」形にした。コンテナ内 `localhost:8080` は自コンテナ（backend）に着地するので docker-compose 側の追加設定ゼロ。

### なぜ gobreaker の閾値を `ConsecutiveFailures >= 3` / `Timeout 5s` / `MaxRequests 1` にしたか

本番相当の「失敗率 + 最小リクエスト数」判定だと UI から遷移を全部観察するのに 20〜30 連打が要る。lab の目的は閾値チューニングではなく状態遷移を目で追うことなので、閾値を低くして「3 連打で Open」「5 秒で Half-Open」「1 リクエスト成功で Closed」が確認できる値に寄せた。本番設計との差分はナレッジメモ側 (`circuit-breaker-essentials.md`) でフォロー。

### なぜ `ErrOpenState` と `ErrTooManyRequests` を両方「source=breaker」にしたか

- `ErrOpenState`: Open 中の短絡。upstream に到達すらしていない。
- `ErrTooManyRequests`: Half-Open 中に既に probe が走っている間の追加リクエストを弾いた。

どちらも「breaker が手前で止めた」意味では同じなので UI では区別しない。詳細は `error` フィールドに文字列で落ちるので、面接で問われたら差分を口頭で説明できる（Half-Open の MaxRequests が何者か、の質問は鉄板）。

### なぜ `Interval=0` にしたか

Closed 中に ConsecutiveFailures を定期リセットしない設定。interval を入れると、短時間に 2 回失敗 → 時間経過で counts リセット → また 2 回失敗、が Open に落ちずに延々続く。lab で「連打 → Open」を確実に再現させたいので切った。本番では逆に「瞬間的な 1〜2 失敗で trip させたくない」ので interval を入れるのが普通。

### なぜ `OnStateChange` だけで counts を UI に出さなかったか

`OnStateChange` は Closed→Open 等の「境界」でしか呼ばれないので、Closed 中に連続失敗が積み上がっていく様子は見えない。UI では別途 `GET /state` を 1s ポーリングして counts も一緒に取得している。