### PR TITLE
feat(lab): #10 SSE で 1 対多 fan-out / heartbeat / 接続管理を観察する API を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,9 @@ db/
   - `GET  /api/lab/breaker/state` — 現在の state / counts / failMode / 状態遷移履歴
   - `POST /api/lab/breaker/toggle-fail` — mock upstream の失敗モードを反転（ON の間は mock が 500 を返す）
   - `GET  /api/lab/breaker/mock` — breaker の保護対象となる mock upstream（fail mode では 500、通常は 200）
+  - `GET  /api/lab/realtime/stream` — SSE エンドポイント（`text/event-stream`）。1 接続 = 1 subscriber。15s 毎に `:hb` ハートビート
+  - `POST /api/lab/realtime/publish` — `{message}` を全 subscriber に fan-out。レスポンスで配信数 / drop 数を返す
+  - `GET  /api/lab/realtime/stats` — 現在の subscriber 数 / 累計送信件数
 
 lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり、docker-compose.lab.yml の `worker` サービスで起動する。1 プロセス内で **2 goroutine が primary / audit を独立に long polling** する構造で、SNS → SQS fanout の両キュー同時消費を観察できる。"fail" を含むメッセージは削除せず redrive policy (maxReceiveCount=3) で DLQ へ送る挙動も観察可能。
 
@@ -97,6 +100,7 @@ lab 用の SQS worker は `cmd/worker` 配下に別バイナリとしてあり�
   - Postgres パーティショニング（partition pruning）: `~/.claude/docs/interview/system-design/postgres-partition-essentials.md`
   - Postgres bulk ingest（個別 / multi-row / COPY / staging の使い分け）: `~/.claude/docs/interview/system-design/postgres-bulk-essentials.md`
   - Circuit Breaker（Closed/Open/Half-Open と閾値設計）: `~/.claude/docs/interview/system-design/circuit-breaker-essentials.md`
+  - SSE（broker fan-out / heartbeat / WebSocket との比較）: `~/.claude/docs/interview/system-design/sse-essentials.md`
 
 main.go では CORS ミドルウェアを適用し、MySQL 接続を最大 10 回・5 秒間隔でリトライ。
 

--- a/main.go
+++ b/main.go
@@ -92,8 +92,12 @@ func main() {
 	if err != nil {
 		e.Logger.Warnf("lab breaker handler init failed, /api/lab/breaker/* disabled: %s", err.Error())
 	}
+	labRealtimeHandler, err := handlers.NewLabRealtimeHandler()
+	if err != nil {
+		e.Logger.Warnf("lab realtime handler init failed, /api/lab/realtime/* disabled: %s", err.Error())
+	}
 
-	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler, labBulkHandler, labBreakerHandler)
+	routes.SetupRoutes(e, tagHandler, schoolHandler, userHandler, authHandler, healthCheckHandler, counselingHandler, labS3Handler, labSQSHandler, labSNSHandler, labLambdaHandler, labCacheHandler, labRLSHandler, labPartitionHandler, labBulkHandler, labBreakerHandler, labRealtimeHandler)
 
 	e.Start(":8080")
 }

--- a/src/handlers/lab_realtime_handler.go
+++ b/src/handlers/lab_realtime_handler.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+// LabRealtimeHandler は SSE (Server-Sent Events) で 1 対多のサーバ push を体感するための lab ハンドラ。
+// publisher → broker → 各 subscriber の channel に fan-out し、subscriber goroutine が
+// HTTP response writer に書き込んで Flush する。
+//
+// SSE を選んだ理由: 一方向 push かつ HTTP/1.1 でそのまま動く（プロキシ・ALB 互換）。
+// 双方向必要なら WebSocket、フル通信が必要なら gRPC stream を選ぶ層分け。
+type LabRealtimeHandler struct {
+	mu          sync.RWMutex
+	subscribers map[int64]chan realtimeEvent
+
+	nextID    atomic.Int64
+	totalSent atomic.Int64
+}
+
+type realtimeEvent struct {
+	ID        int64     `json:"id"`
+	Message   string    `json:"message"`
+	PublishedAt time.Time `json:"publishedAt"`
+}
+
+// NewLabRealtimeHandler は subscribers map のみ初期化する。env も外部接続も無いので失敗しない。
+func NewLabRealtimeHandler() (*LabRealtimeHandler, error) {
+	return &LabRealtimeHandler{
+		subscribers: make(map[int64]chan realtimeEvent),
+	}, nil
+}
+
+// Stream は SSE エンドポイント。クライアントは EventSource("/api/lab/realtime/stream") で接続する。
+//
+// 流れ:
+//  1. このリクエスト専用の channel を作って subscribers に登録
+//  2. 切断時 (ctx.Done) にループを抜けて subscribers から外す
+//  3. ループ内で channel から event を受け取って `data: <json>\n\n` を書き込み Flush
+//  4. 15s 毎にハートビート (`:hb\n\n`) を送ってアイドル切断を防ぐ
+//
+// バッファサイズ 16 にしているのは「遅い consumer が publisher をブロックしない」ため。
+// 溢れたら drop する（lab なので panic より無難な挙動を選ぶ）。
+func (h *LabRealtimeHandler) Stream(c echo.Context) error {
+	w := c.Response()
+	w.Header().Set(echo.HeaderContentType, "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// nginx 経由の場合 proxy buffering を切らないと flush が即時届かない
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	id := h.nextID.Add(1)
+	ch := make(chan realtimeEvent, 16)
+	h.mu.Lock()
+	h.subscribers[id] = ch
+	h.mu.Unlock()
+
+	defer func() {
+		h.mu.Lock()
+		delete(h.subscribers, id)
+		close(ch)
+		h.mu.Unlock()
+	}()
+
+	// 接続直後に「あなたの subscriber id」を hello イベントで返す（UI のデバッグ用）
+	if _, err := fmt.Fprintf(w, "event: hello\ndata: {\"subscriberId\":%d}\n\n", id); err != nil {
+		return nil
+	}
+	w.Flush()
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	ctx := c.Request().Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-heartbeat.C:
+			// SSE のコメント行 (`:` 始まり) はクライアントが無視する。
+			// プロキシ / LB 側の idle timeout を踏まないための keep-alive。
+			if _, err := fmt.Fprint(w, ":hb\n\n"); err != nil {
+				return nil
+			}
+			w.Flush()
+		case ev := <-ch:
+			if _, err := fmt.Fprintf(w, "id: %d\ndata: {\"id\":%d,\"message\":%q,\"publishedAt\":%q}\n\n",
+				ev.ID, ev.ID, ev.Message, ev.PublishedAt.Format(time.RFC3339Nano)); err != nil {
+				return nil
+			}
+			w.Flush()
+		}
+	}
+}
+
+type realtimePublishReq struct {
+	Message string `json:"message"`
+}
+
+type realtimePublishResp struct {
+	ID          int64  `json:"id"`
+	Subscribers int    `json:"subscribers"`
+	Dropped     int    `json:"dropped"`
+}
+
+// Publish は 1 メッセージを全 subscriber に fan-out する。
+// 遅い consumer の channel が満杯なら「その subscriber 宛だけ」drop してカウントを返す。
+// 全員に届いた数 = subscribers - dropped、で UI 側に表示する。
+func (h *LabRealtimeHandler) Publish(c echo.Context) error {
+	var req realtimePublishReq
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if req.Message == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "message is required")
+	}
+	ev := realtimeEvent{
+		ID:          h.totalSent.Add(1),
+		Message:     req.Message,
+		PublishedAt: time.Now(),
+	}
+
+	h.mu.RLock()
+	chans := make([]chan realtimeEvent, 0, len(h.subscribers))
+	for _, ch := range h.subscribers {
+		chans = append(chans, ch)
+	}
+	h.mu.RUnlock()
+
+	dropped := 0
+	for _, ch := range chans {
+		select {
+		case ch <- ev:
+		default:
+			// 遅い consumer は drop。publisher を絶対にブロックしない方針。
+			dropped++
+		}
+	}
+	return c.JSON(http.StatusOK, realtimePublishResp{
+		ID:          ev.ID,
+		Subscribers: len(chans),
+		Dropped:     dropped,
+	})
+}
+
+type realtimeStatsResp struct {
+	Subscribers int   `json:"subscribers"`
+	TotalSent   int64 `json:"totalSent"`
+}
+
+// Stats は UI の「接続中 N 人 / 累計送信 M 件」表示用の軽量エンドポイント。
+func (h *LabRealtimeHandler) Stats(c echo.Context) error {
+	h.mu.RLock()
+	n := len(h.subscribers)
+	h.mu.RUnlock()
+	return c.JSON(http.StatusOK, realtimeStatsResp{
+		Subscribers: n,
+		TotalSent:   h.totalSent.Load(),
+	})
+}

--- a/src/routes/routes.go
+++ b/src/routes/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler, labBulkHandler *handlers.LabBulkHandler, labBreakerHandler *handlers.LabBreakerHandler) {
+func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *handlers.SchoolHandler, userHandler *handlers.UserHandler, authHandler *handlers.AuthHandler, healthCheckHandler *handlers.HealthCheckHandler, counselingHandler *handlers.CounselingHandler, labS3Handler *handlers.LabS3Handler, labSQSHandler *handlers.LabSQSHandler, labSNSHandler *handlers.LabSNSHandler, labLambdaHandler *handlers.LabLambdaHandler, labCacheHandler *handlers.LabCacheHandler, labRLSHandler *handlers.LabRLSHandler, labPartitionHandler *handlers.LabPartitionHandler, labBulkHandler *handlers.LabBulkHandler, labBreakerHandler *handlers.LabBreakerHandler, labRealtimeHandler *handlers.LabRealtimeHandler) {
 	e.GET("/healthcheck", healthCheckHandler.HealthCheck)
 
 	// Lab (学習用、認証なし)。LocalStack 前提でローカル環境のみ使用する。
@@ -52,6 +52,11 @@ func SetupRoutes(e *echo.Echo, tagHandler *handlers.TagHandler, schoolHandler *h
 		lab.GET("/breaker/state", labBreakerHandler.State)
 		lab.POST("/breaker/toggle-fail", labBreakerHandler.ToggleFail)
 		lab.GET("/breaker/mock", labBreakerHandler.Mock)
+	}
+	if labRealtimeHandler != nil {
+		lab.GET("/realtime/stream", labRealtimeHandler.Stream)
+		lab.POST("/realtime/publish", labRealtimeHandler.Publish)
+		lab.GET("/realtime/stats", labRealtimeHandler.Stats)
 	}
 	// Auth
 	// [TODO]/api/userは「/api/signup」として切り分けたい


### PR DESCRIPTION
fanc-lab カリキュラム #10 のバックエンド実装。SSE (Server-Sent Events) で 1 対多のサーバ push を体感する。同プロセス内に subscribers map を持つ broker を置き、publish 時に全 subscriber の channel へ fan-out する。

## 実装概要

| ファイル | 変更 |
|---|---|
| `src/handlers/lab_realtime_handler.go` | 新規。`subscribers map[int64]chan` + RWMutex の broker、SSE stream / publish / stats の 3 ハンドラ |
| `src/routes/routes.go` / `main.go` | ハンドラ登録。他 lab と同じく init 失敗時は warn ログだけで無効化 |
| `CLAUDE.md` | lab API 一覧 / ナレッジ参照に #10 を追記 |

### API の形

```
GET  /api/lab/realtime/stream
 → text/event-stream
   event: hello
   data: {"subscriberId":N}

   id: 1
   data: {"id":1,"message":"...","publishedAt":"..."}

   :hb            # 15s 毎の heartbeat (SSE コメント行)

POST /api/lab/realtime/publish    {message:"..."}
 → { id, subscribers, dropped }

GET  /api/lab/realtime/stats
 → { subscribers, totalSent }
```

## 設計判断の「なぜ」

### なぜ WebSocket ではなく SSE にしたか

curriculum は「SSE / WebSocket」だが、まずは SSE に絞った。lab の目的は「サーバから push される構造を体感する」ことで、双方向通信は要らない。SSE なら HTTP/1.1 そのまま（ALB / nginx / CloudFront 互換）、ブラウザ側も `EventSource` 一発で実装が最小、自動再接続も標準実装。WebSocket を入れた瞬間に upgrade ハンドシェイク・ping/pong・フレーム境界・再接続ロジックの実装が必要になり、lab のスコープを超える。WebSocket が要る要件（チャット入力など双方向）は別 lab で扱う想定。

### なぜ broker を `map[int64]chan` + RWMutex にしたか

「subscribe 時のみ write、publish/stats は read」という read-heavy ワークロードなので RWMutex が素直。subscriber id を `atomic.Int64` で発番して map のキーにすることで、削除時に slice の linear search を避けている。subscriber 数が数千を超える本番想定なら sharded map / sync.Map に切り替える層分け（lab スケールでは過剰）。

### なぜ publisher を non-blocking send（`select { case ch <- ev: default: drop }`）にしたか

publisher は HTTP リクエストの応答パスなので「1 人の遅い subscriber が他全員と publisher 自身をブロックする」のが最悪パターン。channel を満杯にした subscriber 宛だけ drop して、配信数 / drop 数をレスポンスに載せる方針にした。本番だと「drop されたら subscriber 側を切断 → 再接続させる」が定石（at-least-once を諦めるか、Last-Event-ID で resume する）。

### なぜ heartbeat を 15s にしたか

ALB / CloudFront / nginx のデフォルト idle timeout は 60s 前後。15s はその 1/4 以下に収まる安全圏。SSE の仕様で `:` で始まる行はコメント扱いなので `:hb\n\n` で十分。client 側のロジックは何も追加せず keep-alive だけが目的。

### なぜ自前で SSE フォーマットを書いたか（echo の helper を使わない）

echo に SSE 専用ヘルパーは無い。`response.Flush()` と `Content-Type: text/event-stream` ヘッダだけで標準の SSE は成立するので、外部ライブラリ依存を増やさずに最小コードで書いた。`X-Accel-Buffering: no` を入れているのは nginx 経由のとき flush が即座に届くようにするため（ALB 直の本番では不要だが付けても害はない）。

## 本番との差分（口頭で話せるポイント）

- **スケールアウト**: 単一プロセスの `map` なので複数インスタンス間で publish が共有されない。本番は Redis Pub/Sub or NATS or Kafka を broker にして「どの instance に subscribe している client にも届く」構成にする。
- **再接続 / resume**: `id:` ヘッダは送っているが、サーバ側で過去イベントを保持していないので Last-Event-ID リプレイは未実装。本番なら直近 N 件を ring buffer に持つ or 永続ストアから引く。
- **認証**: lab では認証なし。本番は cookie / Authorization ヘッダで identify、subscriber 単位のフィルタ（自分宛のみ受信）が要る。EventSource は `Authorization` ヘッダ非対応なので cookie 認証 or `?token=...` の選択を意識する。
- **back-pressure**: drop は雑な対処。本番は subscriber 側の処理速度に応じた flow control、または「drop が起きた subscriber は 1 度切って再接続させる」のいずれか。

## Test plan

- [x] `go build ./...` / `go vet ./...` 通過
- [ ] `make up-lab` で起動 → `curl -N http://localhost:8080/api/lab/realtime/stream` で hello + heartbeat を確認
- [ ] 別タブで `POST /api/lab/realtime/publish` を投げて受信側に届くことを確認
- [ ] 2 接続張った状態で `/stats` の subscribers が 2 になることを確認
- [ ] 接続切断（Ctrl-C）後に subscribers が 1 → 0 に戻ることを確認

Closes なし（カリキュラム進捗表は `.claude/docs/interview/system-design/fanc-lab/curriculum.md` を参照）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)